### PR TITLE
Type Synonym Instances are required for GHC 7.0.4

### DIFF
--- a/src/Generics/Deriving/ConNames.hs
+++ b/src/Generics/Deriving/ConNames.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE TypeSynonymInstances  #-}
 
 -----------------------------------------------------------------------------
 -- |


### PR DESCRIPTION
We turned to `generic-deriving` to support `GHC.Generics` along with the 2011.4.0.0 Haskell platform in `lens` 3.7, but `generic-deriving` doesn't build without this extra pragma in GHC 7.0.4.

Would it be possible for you to push a point-release to Hackage fixing this, even if you aren't ready to ship the rest of 1.4? 

GHC 7.0.4 support in `lens` is the only thing holding up the next version of the `snap-framework` and my only alternative is disabling part of my API or making it conditional.
