### PR TITLE
Fix for building with GHC 7.7/TH 2.9

### DIFF
--- a/generic-deriving.cabal
+++ b/generic-deriving.cabal
@@ -23,7 +23,7 @@ maintainer:             generics@haskell.org
 stability:              experimental
 build-type:             Simple
 cabal-version:          >= 1.6
-tested-with:            GHC == 7.0.3, GHC == 7.2.1, GHC == 7.4.1, GHC == 7.6.1
+tested-with:            GHC == 7.0.3, GHC == 7.2.1, GHC == 7.4.1, GHC == 7.6.1, GHC == 7.7.20130624
 extra-source-files:     examples/Examples.hs
 
 source-repository head

--- a/src/Generics/Deriving/TH.hs
+++ b/src/Generics/Deriving/TH.hs
@@ -109,7 +109,7 @@ deriveInst t = do
   let typ q = foldl (\a -> AppT a . VarT . tyVarBndrToName) (ConT q) 
                 (typeVariables i)
 #if __GLASGOW_HASKELL__ >= 707
-  let tyIns = TySynInstD ''Rep (fmap (TySynEqn [typ (genRepName 0 t)]) [typ t])
+  let tyIns = TySynInstD ''Rep (TySynEqn [typ t] (typ (genRepName 0 t)))
 #else
   let tyIns = TySynInstD ''Rep [typ t] (typ (genRepName 0 t))
 #endif


### PR DESCRIPTION
They changed the TH API: https://github.com/ghc/packages-template-haskell/commit/e4f742d5f70eefb1e0a7542762f34e7a50f6fcef#Language/Haskell/TH/Syntax.hs
so it needed another fix.
