### PR TITLE
Implement `Generics.Deriving.Comonad`.

### DIFF
--- a/generic-deriving.cabal
+++ b/generic-deriving.cabal
@@ -35,12 +35,14 @@ library
   exposed-modules:      Generics.Deriving
                         Generics.Deriving.Base
                         Generics.Deriving.Instances
+                        Generics.Deriving.Comonad
                         Generics.Deriving.Copoint
                         Generics.Deriving.ConNames
                         Generics.Deriving.Enum
                         Generics.Deriving.Eq
                         Generics.Deriving.Foldable
                         Generics.Deriving.Functor
+                        Generics.Deriving.Internal.Functor
                         Generics.Deriving.Monoid
                         Generics.Deriving.Show
                         Generics.Deriving.Traversable

--- a/src/Generics/Deriving/Comonad.hs
+++ b/src/Generics/Deriving/Comonad.hs
@@ -93,7 +93,18 @@ And you can use @'Monoid' m => 'GComonad' ((->) m)@:
 data W'' a = C'' ((Product Int) -> a) deriving ('Generic1')
 instance 'GComonad' W''
 @
+
+To make your type an instance of @Control.Comonad.Comonad@ from the @comonad@ package,
+simply use 'gduplicate' and 'gextract':
+
+@
+instance Comonad W where
+  duplicate = gduplicate
+  extract = gextract
+@
+
 -}
+
 class GComonad w where
   gduplicate :: w a -> w (w a)
 #if __GLASGOW_HASKELL__ >= 701

--- a/src/Generics/Deriving/Comonad.hs
+++ b/src/Generics/Deriving/Comonad.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 701
+{-# LANGUAGE DefaultSignatures #-}
+#endif
+
+module Generics.Deriving.Comonad (
+  -- * GComonad class
+  GComonad(..)
+  
+  -- * Default methods
+  , gduplicatedefault
+  , gextractdefault
+  
+  ) where
+
+import Generics.Deriving.Base
+import Generics.Deriving.Instances ()
+import Generics.Deriving.Internal.Functor
+
+class GComonad' w where
+  gduplicate' :: w a -> w (w a)
+  gextract' :: w a -> a
+  
+instance GComonad' Par1 where
+  gduplicate' = Par1
+  {-# INLINE gduplicate' #-}
+  gextract'   = unPar1
+  {-# INLINE gextract' #-}
+
+instance (GFunctor' a, GFunctor' w, GComonad' w) => GComonad' (a :*: w) where
+  gduplicate' w@(a :*: b) = gmap' (const w) a :*: gmap' (const w) b
+  gextract' (_ :*: b) = gextract' b
+
+instance (GFunctor' f, GFunctor' g, GComonad' f, GComonad' g) => GComonad' (f :+: g) where
+  gduplicate' w@(L1 a) = L1 . gmap' (const w) $ a
+  gduplicate' w@(R1 a) = R1 . gmap' (const w) $ a
+  gextract' (L1 a) = gextract' a
+  gextract' (R1 a) = gextract' a
+  
+instance (GComonad' f, GFunctor' f) => GComonad' (M1 i c f) where
+  gduplicate' w@(M1 a) = M1 (gmap' (const w) a)
+  gextract' (M1 a) = gextract' a
+{- |
+
+Generically derived comonads.
+
+Instances are available for any type of the form 
+
+@
+data W a =
+    C1 [t11 t12 .. t1N] a
+ [| C2 [t21 t22 .. t2N] a
+  | .. ]
+  deriving ('Generic1')
+instance 'GFunctor' W 
+@
+
+In other words, each constructor must include @a@ in the rightmost position.
+
+If @a@ appears in other positions, it will be ignored by 'gextract'.
+
+-}
+class GComonad w where
+  gduplicate :: w a -> w (w a)
+  default gduplicate :: (Generic1 w, GFunctor' (Rep1 w), GComonad' (Rep1 w))
+                     => w a -> w (w a)
+  gduplicate = to1 . gmap' to1 . gduplicate' . from1
+  
+  gextract :: w a -> a
+  default gextract :: (Generic1 w, GComonad' (Rep1 w))
+                   => w a -> a
+  gextract = gextract' . from1
+
+gduplicatedefault :: (Generic1 w, GFunctor' (Rep1 w), GComonad' (Rep1 w))
+                  => w a -> w (w a)
+gduplicatedefault = to1 . gmap' to1 . gduplicate' . from1
+
+gextractdefault :: (Generic1 w, GComonad' (Rep1 w))
+                => w a -> a
+gextractdefault = gextract' . from1
+

--- a/src/Generics/Deriving/Comonad.hs
+++ b/src/Generics/Deriving/Comonad.hs
@@ -149,3 +149,6 @@ instance GConstant' U1 where
   
 instance (GConstant' f) => GConstant' (M1 i c f) where
   gcast' (M1 a) = M1 (gcast' a)
+
+instance (GConstant' f, GConstant' g) => GConstant' (f :*: g) where
+  gcast' (a :*: b) = gcast' a :*: gcast' b

--- a/src/Generics/Deriving/Comonad.hs
+++ b/src/Generics/Deriving/Comonad.hs
@@ -69,12 +69,21 @@ data W a =
   | .. ]
   deriving ('Generic1')
 instance 'GFunctor' W 
+instance 'GComonad' W
 @
 
 In other words, each constructor must include @a@ in the rightmost position.
 
 If @a@ appears in other positions, it will be ignored by 'gextract'.
 The resulting `GComonad` instance will therefore violate the comonad laws.
+
+You may also wrap a type that is itself an instance of 'GComonad':
+
+@
+data W' a = C'1 a | C'2 (W a) deriving ('Generic1')
+instance 'GFunctor' W'
+instance 'GComonad' W'
+@
 
 -}
 class GComonad w where

--- a/src/Generics/Deriving/Comonad.hs
+++ b/src/Generics/Deriving/Comonad.hs
@@ -22,12 +22,16 @@ import Generics.Deriving.Internal.Functor
 class GComonad' w where
   gduplicate' :: w a -> w (w a)
   gextract' :: w a -> a
-  
+
 instance GComonad' Par1 where
   gduplicate' = Par1
   {-# INLINE gduplicate' #-}
   gextract'   = unPar1
   {-# INLINE gextract' #-}
+
+instance (GComonad f, GFunctor f) => GComonad' (Rec1 f) where
+  gduplicate' w@(Rec1 a) = Rec1 $ gmap (const w) a
+  gextract' (Rec1 a) = gextract a
 
 instance (GFunctor' a, GFunctor' w, GComonad' w) => GComonad' (a :*: w) where
   gduplicate' w@(a :*: b) = gmap' (const w) a :*: gmap' (const w) b
@@ -42,6 +46,12 @@ instance (GFunctor' f, GFunctor' g, GComonad' f, GComonad' g) => GComonad' (f :+
 instance (GComonad' f, GFunctor' f) => GComonad' (M1 i c f) where
   gduplicate' w@(M1 a) = M1 (gmap' (const w) a)
   gextract' (M1 a) = gextract' a
+
+instance (GFunctor f, GFunctor' g, GComonad f, GComonad' g) => GComonad' (f :.: g) where
+  gduplicate' w@(Comp1 x) = gmap' (const $ Comp1 x) w
+  gextract' (Comp1 x) = gextract' $ gextract x
+  {-# INLINE gextract' #-}
+
 {- |
 
 Generically derived comonads.

--- a/src/Generics/Deriving/Comonad.hs
+++ b/src/Generics/Deriving/Comonad.hs
@@ -19,6 +19,8 @@ import Generics.Deriving.Base
 import Generics.Deriving.Instances ()
 import Generics.Deriving.Internal.Functor
 
+import Data.Monoid (Monoid, mappend, mempty )
+
 class GComonad' w where
   gduplicate' :: w a -> w (w a)
   gextract' :: w a -> a
@@ -85,6 +87,13 @@ instance 'GFunctor' W'
 instance 'GComonad' W'
 @
 
+And you can use @'Monoid' m => 'GComonad' ((->) m)@:
+
+@
+data W'' a = C'' ((Product Int) -> a) deriving ('Generic1')
+instance 'GFunctor' W''
+instance 'GComonad' W''
+@
 -}
 class GComonad w where
   gduplicate :: w a -> w (w a)
@@ -105,3 +114,10 @@ gextractdefault :: (Generic1 w, GComonad' (Rep1 w))
                 => w a -> a
 gextractdefault = gextract' . from1
 
+-- Instances for Prelude types, to enable use in derived types
+
+instance Monoid m => GComonad ((->) m) where
+  gduplicate f m = f . mappend m
+  {-# INLINE gduplicate #-}
+  gextract f = f mempty
+  {-# INLINE gextract #-}

--- a/src/Generics/Deriving/Comonad.hs
+++ b/src/Generics/Deriving/Comonad.hs
@@ -60,6 +60,7 @@ instance 'GFunctor' W
 In other words, each constructor must include @a@ in the rightmost position.
 
 If @a@ appears in other positions, it will be ignored by 'gextract'.
+The resulting `GComonad` instance will therefore violate the comonad laws.
 
 -}
 class GComonad w where

--- a/src/Generics/Deriving/Comonad.hs
+++ b/src/Generics/Deriving/Comonad.hs
@@ -32,20 +32,24 @@ instance GComonad' Par1 where
 instance (GComonad f, GFunctor f) => GComonad' (Rec1 f) where
   gduplicate' w@(Rec1 a) = Rec1 $ gmap (const w) a
   gextract' (Rec1 a) = gextract a
+  {-# INLINE gextract' #-}
 
 instance (GFunctor' a, GFunctor' w, GComonad' w) => GComonad' (a :*: w) where
   gduplicate' w@(a :*: b) = gmap' (const w) a :*: gmap' (const w) b
   gextract' (_ :*: b) = gextract' b
+  {-# INLINE gextract' #-}
 
 instance (GFunctor' f, GFunctor' g, GComonad' f, GComonad' g) => GComonad' (f :+: g) where
   gduplicate' w@(L1 a) = L1 . gmap' (const w) $ a
   gduplicate' w@(R1 a) = R1 . gmap' (const w) $ a
   gextract' (L1 a) = gextract' a
   gextract' (R1 a) = gextract' a
+  {-# INLINE gextract' #-}
   
 instance (GComonad' f, GFunctor' f) => GComonad' (M1 i c f) where
   gduplicate' w@(M1 a) = M1 (gmap' (const w) a)
   gextract' (M1 a) = gextract' a
+  {-# INLINE gextract' #-}
 
 instance (GFunctor f, GFunctor' g, GComonad f, GComonad' g) => GComonad' (f :.: g) where
   gduplicate' w@(Comp1 x) = gmap' (const $ Comp1 x) w

--- a/src/Generics/Deriving/Comonad.hs
+++ b/src/Generics/Deriving/Comonad.hs
@@ -96,14 +96,18 @@ instance 'GComonad' W''
 -}
 class GComonad w where
   gduplicate :: w a -> w (w a)
+#if __GLASGOW_HASKELL__ >= 701
   default gduplicate :: (Generic1 w, GFunctor' (Rep1 w), GComonad' (Rep1 w))
                      => w a -> w (w a)
   gduplicate = to1 . gmap' to1 . gduplicate' . from1
+#endif
   
   gextract :: w a -> a
+#if __GLASGOW_HASKELL__ >= 701
   default gextract :: (Generic1 w, GComonad' (Rep1 w))
                    => w a -> a
   gextract = gextract' . from1
+#endif
 
 gduplicatedefault :: (Generic1 w, GFunctor' (Rep1 w), GComonad' (Rep1 w))
                   => w a -> w (w a)

--- a/src/Generics/Deriving/Functor.hs
+++ b/src/Generics/Deriving/Functor.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 701
-{-# LANGUAGE DefaultSignatures #-}
-#endif
 
 module Generics.Deriving.Functor (
   -- * GFunctor class
@@ -14,57 +8,4 @@ module Generics.Deriving.Functor (
 
   ) where
 
-import Generics.Deriving.Base
-import Generics.Deriving.Instances ()
-
---------------------------------------------------------------------------------
--- Generic fmap
---------------------------------------------------------------------------------
-
-class GFunctor' f where
-  gmap' :: (a -> b) -> f a -> f b
-
-instance GFunctor' U1 where
-  gmap' _ U1 = U1
-
-instance GFunctor' Par1 where
-  gmap' f (Par1 a) = Par1 (f a)
-
-instance GFunctor' (K1 i c) where
-  gmap' _ (K1 a) = K1 a
-
-instance (GFunctor f) => GFunctor' (Rec1 f) where
-  gmap' f (Rec1 a) = Rec1 (gmap f a)
-
-instance (GFunctor' f) => GFunctor' (M1 i c f) where
-  gmap' f (M1 a) = M1 (gmap' f a)
-
-instance (GFunctor' f, GFunctor' g) => GFunctor' (f :+: g) where
-  gmap' f (L1 a) = L1 (gmap' f a)
-  gmap' f (R1 a) = R1 (gmap' f a)
-
-instance (GFunctor' f, GFunctor' g) => GFunctor' (f :*: g) where
-  gmap' f (a :*: b) = gmap' f a :*: gmap' f b
-
-instance (GFunctor f, GFunctor' g) => GFunctor' (f :.: g) where
-  gmap' f (Comp1 x) = Comp1 (gmap (gmap' f) x)
-
-
-class GFunctor f where
-  gmap :: (a -> b) -> f a -> f b
-#if __GLASGOW_HASKELL__ >= 701
-  default gmap :: (Generic1 f, GFunctor' (Rep1 f))
-               => (a -> b) -> f a -> f b
-  gmap = gmapdefault
-#endif
-
-gmapdefault :: (Generic1 f, GFunctor' (Rep1 f))
-            => (a -> b) -> f a -> f b
-gmapdefault f = to1 . gmap' f . from1
-
--- Base types instances
-instance GFunctor Maybe where
-  gmap = gmapdefault
-
-instance GFunctor [] where
-  gmap = gmapdefault
+import Generics.Deriving.Internal.Functor

--- a/src/Generics/Deriving/Internal/Functor.hs
+++ b/src/Generics/Deriving/Internal/Functor.hs
@@ -65,3 +65,7 @@ instance GFunctor Maybe where
 
 instance GFunctor [] where
   gmap = gmapdefault
+  
+-- Necessary for GComonad
+instance GFunctor ((->) e) where
+  gmap = fmap

--- a/src/Generics/Deriving/Internal/Functor.hs
+++ b/src/Generics/Deriving/Internal/Functor.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 701
+{-# LANGUAGE DefaultSignatures #-}
+#endif
+
+module Generics.Deriving.Internal.Functor (
+    GFunctor'(..)
+  , GFunctor(..)
+  , gmapdefault
+  ) where
+
+import Generics.Deriving.Base
+import Generics.Deriving.Instances ()
+
+--------------------------------------------------------------------------------
+-- Generic fmap
+--------------------------------------------------------------------------------
+
+class GFunctor' f where
+  gmap' :: (a -> b) -> f a -> f b
+
+instance GFunctor' U1 where
+  gmap' _ U1 = U1
+
+instance GFunctor' Par1 where
+  gmap' f (Par1 a) = Par1 (f a)
+
+instance GFunctor' (K1 i c) where
+  gmap' _ (K1 a) = K1 a
+
+instance (GFunctor f) => GFunctor' (Rec1 f) where
+  gmap' f (Rec1 a) = Rec1 (gmap f a)
+
+instance (GFunctor' f) => GFunctor' (M1 i c f) where
+  gmap' f (M1 a) = M1 (gmap' f a)
+
+instance (GFunctor' f, GFunctor' g) => GFunctor' (f :+: g) where
+  gmap' f (L1 a) = L1 (gmap' f a)
+  gmap' f (R1 a) = R1 (gmap' f a)
+
+instance (GFunctor' f, GFunctor' g) => GFunctor' (f :*: g) where
+  gmap' f (a :*: b) = gmap' f a :*: gmap' f b
+
+instance (GFunctor f, GFunctor' g) => GFunctor' (f :.: g) where
+  gmap' f (Comp1 x) = Comp1 (gmap (gmap' f) x)
+
+
+class GFunctor f where
+  gmap :: (a -> b) -> f a -> f b
+#if __GLASGOW_HASKELL__ >= 701
+  default gmap :: (Generic1 f, GFunctor' (Rep1 f))
+               => (a -> b) -> f a -> f b
+  gmap = gmapdefault
+#endif
+
+gmapdefault :: (Generic1 f, GFunctor' (Rep1 f))
+            => (a -> b) -> f a -> f b
+gmapdefault f = to1 . gmap' f . from1
+
+-- Base types instances
+instance GFunctor Maybe where
+  gmap = gmapdefault
+
+instance GFunctor [] where
+  gmap = gmapdefault


### PR DESCRIPTION
This allows deriving `Comonad` instances for a limited but useful range of functors. I believe this mechanism can produce `Comonad` instances for data types that are equivalent to reader comonads, `Env f` for some `f`. So `data W a = C1 a | C2 X Y a | C3 a a` works, with the proviso that `gextract` disregards the first `a` in `C3`. Therefore the `fmap gextract . gduplicate = id` law is broken for any constructor that uses `a` in any but the rightmost position.

*Edit*: As of a53b9e0942006763b2ed69ee8f35442d65f41bec, `C3 a a` is no  longer permitted and that rule violation is excluded.

*Edit*: Also note that a few other types may now derive `GComonad`, including some recursive and function types.

I have not proved the validity of these instances. Their behavior seems sensible for the types I tested, such as `W` above.

I think it would be possible to accept constructors like `data W' = C4 a X` with the use of fancy footwork. I haven't looked into it in detail; it seems like it would require type families.

Several `GComonad'` instances need access to `GFunctor'` member functions. To expose those functions, I moved Generics.Deriving.Functor to an internal module that exposes the implementation class, and created a thin wrapper that only exports the public API.