### PR TITLE
Expose TH functions on all versions of GHC (fixes #15)

### DIFF
--- a/src/Generics/Deriving/TH.hs
+++ b/src/Generics/Deriving/TH.hs
@@ -25,12 +25,10 @@ module Generics.Deriving.TH (
     , deriveConstructors
     , deriveSelectors
 
-#if __GLASGOW_HASKELL__ < 701
     , deriveAll
     , deriveRepresentable0
     , deriveRep0
     , simplInstance
-#endif
   ) where
 
 import Generics.Deriving.Base


### PR DESCRIPTION
This just removes the `#if __GLASGOW_HASKELL__ < 701 ... #endif` barrier.