### PR TITLE
Allow TH generation of data types with infix constructors

### DIFF
--- a/examples/Examples.hs
+++ b/examples/Examples.hs
@@ -102,7 +102,7 @@ instance Uniplate Tree where
   descend    = descenddefault
   descendM   = descendMdefault
   transform  = transformdefault
-  transformM = transformdefault
+  transformM = transformMdefault
 instance GEnum    Tree where genum      = genumDefault
 
 #endif
@@ -179,7 +179,7 @@ instance (Uniplate a) => Uniplate (List a) where
   descend    = descenddefault
   descendM   = descendMdefault
   transform  = transformdefault
-  transformM = transformdefault
+  transformM = transformMdefault
 
 #else
 
@@ -224,7 +224,7 @@ $(deriveRepresentable0 ''Nested)
 deriving instance Generic1 Nested
 #else
 
-type RepNested = D1 Nested_ (C1 Nested_Leaf_ U1 :+: C1 Nested_Nested_ (Par1 :*: Nested :.: Rec1 []))
+type RepNested = D1 NNested_ (C1 NNested_NLeaf_ U1 :+: C1 NNested_NNested_ (Par1 :*: Nested :.: Rec1 []))
 instance Generic1 Nested where
   type Rep1 Nested = RepNested
   from1 Leaf = M1 (L1 (M1 U1))
@@ -344,7 +344,7 @@ $(deriveRepresentable0 ''GRose)
 deriving instance (Functor f) => Generic1 (GRose f)
 #else
 
-type Rep1GRose f = D1 GRose_ (C1 GRose_GRose_ (Rec1 f :*: f :.: (Rec1 (GRose f))))
+type Rep1GRose f = D1 NGRose_ (C1 NGRose_NGRose_ (Rec1 f :*: f :.: (Rec1 (GRose f))))
 instance (GFunctor f) => Generic1 (GRose f) where
   type Rep1 (GRose f) = Rep1GRose f
   from1 (GRose a x) = M1 (M1 (Rec1 a :*: Comp1 (gmap Rec1 x)))

--- a/examples/Examples.hs
+++ b/examples/Examples.hs
@@ -30,7 +30,8 @@ import Generics.Deriving.TH
 
 data (:/:) f a = MyType1Nil
                | MyType1Cons { myType1Rec :: (f :/: a), myType2Rec :: MyType2 }
-               | MyType1Cons2 (f :/: a) Int a (f a) 
+               | MyType1Cons2 (f :/: a) Int a (f a)
+               | (f :/: a) :/: MyType2
 
 #if __GLASGOW_HASKELL__ >= 701
   deriving Generic

--- a/generic-deriving.cabal
+++ b/generic-deriving.cabal
@@ -1,5 +1,5 @@
 name:                   generic-deriving
-version:                1.7.0
+version:                1.8.0
 synopsis:               Generic programming library for generalised deriving.
 description:
 


### PR DESCRIPTION
Currently, the Template Haskell mechanism for deriving `Generic` doesn't work correctly for data types with infix constructors. For example, if you have this:

```haskell
data Infix a b = a :?: b
$(deriveAll ''Infix)
```

Then `deriveAll` would attempt to define `data Infix_:?:_`, which Template Haskell rejects.

To get around this, I use a trick from [`genifunctors`](https://github.com/danr/genifunctors/blob/4677bb57423b1b380ce9b50cc3d765a5c49a957a/Data/Generics/Genifunctors.hs#L272-278) and sanitize each `nameBase` before being used in a type name. Non-alphanumeric characters are replaced by their ASCII codes, so the above example would generate `data NInfix_N_58_63_58_` instead.

Since this changes the names of generated identifiers, I had to make some changes to `Examples.hs` to make it work again.