### PR TITLE
Support TH deriving of constructor-less datatypes

### DIFF
--- a/examples/Examples.hs
+++ b/examples/Examples.hs
@@ -28,6 +28,8 @@ import Generics.Deriving.TH
 -- Temporary tests for TH generation
 --------------------------------------------------------------------------------
 
+data Empty a
+
 data (:/:) f a = MyType1Nil
                | MyType1Cons { myType1Rec :: (f :/: a), myType2Rec :: MyType2 }
                | MyType1Cons2 (f :/: a) Int a (f a)
@@ -41,11 +43,13 @@ data MyType2 = MyType2 Float ([] :/: Int)
 
 #if __GLASGOW_HASKELL__ < 701
 
+$(deriveAll ''Empty)
 $(deriveAll ''(:/:))
 $(deriveAll ''MyType2)
 
 #else
 
+deriving instance Generic (Empty a)
 -- deriving instance Generic (f :/: a)
 deriving instance Generic MyType2
 


### PR DESCRIPTION
Currently, the TH mechanism in `generic-deriving` has a corner case where it won't generate definitions for `from` and `to` with constructor-less datatypes, e.g.,

```haskell
{-# LANGUAGE TemplateHaskell, TypeFamilies #-}
module Test where

import Generics.Deriving.TH

data Wat a

$(deriveAll ''Wat)

======>

data Wat_
instance GHC.Generics.Datatype Wat_
    where GHC.Generics.datatypeName _ = "Wat"
          GHC.Generics.moduleName _ = "Ghci1"
type Rep0Wat_ (a_0 :: *) = GHC.Generics.D1 Wat_ GHC.Generics.V1
instance GHC.Generics.Generic (Ghci1.Wat a_0)
    where type GHC.Generics.Rep (Ghci1.Wat a_0) = Rep0Wat_ a_0
```
```
Test.hs:8:3:
    Function binding for ‘GHC.Generics.from’ has no equations
    When splicing a TH declaration:
      instance GHC.Generics.Generic (Test.Wat a_0)
    where type GHC.Generics.Rep (Test.Wat a_0) = Rep0Wat_ a_0
```

This pull request addresses this by adding error clauses for `from` and `to` when there are no constructors. I added a proof-of-concept in the `Examples.hs` file.