### PR TITLE
Ensure generated names are unique

### DIFF
--- a/examples/Examples.hs
+++ b/examples/Examples.hs
@@ -13,6 +13,7 @@
 #if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE DeriveGeneric #-}
 #endif
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Main (
   -- * Run all tests
@@ -22,7 +23,7 @@ module Main (
 import Prelude hiding (Either(..))
 import Generics.Deriving
 import Generics.Deriving.TH
-
+import qualified Text.Read.Lex (Lexeme)
 
 --------------------------------------------------------------------------------
 -- Temporary tests for TH generation
@@ -68,6 +69,12 @@ deriving instance Generic1 Empty
 $(deriveRepresentable1 ''Empty)
 $(deriveRepresentable1 ''(:/:))
 #endif
+
+-- Test to see if generated names are unique
+data Lexeme = Lexeme
+
+$(deriveAll ''Main.Lexeme)
+$(deriveAll ''Text.Read.Lex.Lexeme)
 
 --------------------------------------------------------------------------------
 -- Example: Haskell's lists and Maybe
@@ -355,7 +362,8 @@ $(deriveRepresentable0 ''GRose)
 deriving instance (Functor f) => Generic1 (GRose f)
 #else
 
-type Rep1GRose f = D1 NGRose_ (C1 NGRose_NGRose_ (Rec1 f :*: f :.: (Rec1 (GRose f))))
+type Rep1GRose f =
+    D1 NMain_46GRose_ (C1 NMain_46GRose_NMain_46GRose_ (Rec1 f :*: f :.: (Rec1 (GRose f))))
 instance (GFunctor f) => Generic1 (GRose f) where
   type Rep1 (GRose f) = Rep1GRose f
   from1 (GRose a x) = M1 (M1 (Rec1 a :*: Comp1 (gmap Rec1 x)))


### PR DESCRIPTION
The generated datatypes and type synonyms from functions in the `Generics.Deriving.TH` module can conflict. For example:

```haskell
{-# LANGUAGE TemplateHaskell, TypeFamilies #-}
module Example where

import           Generics.Deriving.TH
import qualified Text.Read.Lex

data Lexeme a = Lexeme a

$(deriveData ''Example.Lexeme)
$(deriveData ''Text.Read.Lex.Lexeme)
```

Compiling this with `-ddump-splices` reveals the issue:

```haskell
../Example.hs:12:3-29: Splicing declarations
    deriveData ''Lexeme
  ======>
    data NLexeme_
    instance GHC.Generics.Datatype NLexeme_ where
      GHC.Generics.datatypeName _ = "Lexeme"
      GHC.Generics.moduleName _ = "Example"
../Example.hs:13:3-35: Splicing declarations
    deriveData ''Text.Read.Lex.Lexeme
  ======>
    data NLexeme_
    instance GHC.Generics.Datatype NLexeme_ where
      GHC.Generics.datatypeName _ = "Lexeme"
      GHC.Generics.moduleName _ = "Text.Read.Lex"

../Example.hs:13:3:
    Multiple declarations of ‘NLexeme_’
    Declared at: ../Example.hs:12:3
                 ../Example.hs:13:3
```

I think the easiest fix would be to use the full, qualified name for each generated name, not just the `nameBase`, which this pull request accomplishes. For the above example, the new generated code would be:

```haskell
../Example.hs:12:3-29: Splicing declarations
    deriveData ''Lexeme
  ======>
    data NExample_46Lexeme_
    instance GHC.Generics.Datatype NExample_46Lexeme_ where
      GHC.Generics.datatypeName _ = "Lexeme"
      GHC.Generics.moduleName _ = "Example"
../Example.hs:13:3-35: Splicing declarations
    deriveData ''Text.Read.Lex.Lexeme
  ======>
    data NText_46Read_46Lex_46Lexeme_
    instance GHC.Generics.Datatype NText_46Read_46Lex_46Lexeme_ where
      GHC.Generics.datatypeName _ = "Lexeme"
      GHC.Generics.moduleName _ = "Text.Read.Lex"
```

(I also fixed the build on GHC HEAD while I was at it.)