### PR TITLE
Incorporate unlifted types–related changes

### DIFF
--- a/examples/Examples.hs
+++ b/examples/Examples.hs
@@ -115,8 +115,8 @@ $(deriveRepresentable1 'MyType3False)
 # endif
 
 # if __GLASGOW_HASKELL__ >= 711
-deriving instance Generic (MyType3Hash Int b)
-deriving instance Generic1 (MyType3Hash Int)
+deriving instance Generic  (MyType3 Int b)
+deriving instance Generic1 (MyType3 Int)
 # else
 $(deriveAll0And1 'MyType3Hash)
 # endif

--- a/examples/Examples.hs
+++ b/examples/Examples.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE DatatypeContexts #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE MagicHash #-}
 #if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE DeriveGeneric #-}
 #endif
@@ -24,6 +25,7 @@ module Main (
 import Prelude hiding (Either(..))
 import Generics.Deriving
 import Generics.Deriving.TH
+import GHC.Exts (Addr#, Char#, Double#, Float#, Int#, Word#)
 import qualified Text.Read.Lex (Lexeme)
 
 --------------------------------------------------------------------------------
@@ -46,6 +48,7 @@ data (:/:) f a = MyType1Nil
 #endif
 
 data MyType2 = MyType2 Float ([] :/: Int)
+data PlainHash a = Hash a Addr# Char# Double# Float# Int# Word#
 
 #if __GLASGOW_HASKELL__ >= 701
 deriving instance Generic (Empty a)
@@ -71,6 +74,13 @@ $(deriveRepresentable1 ''Empty)
 $(deriveRepresentable1 ''(:/:))
 #endif
 
+#if __GLASGOW_HASKELL__ >= 711
+deriving instance Generic (PlainHash a)
+deriving instance Generic1 PlainHash
+#else
+$(deriveAll0And1 ''PlainHash)
+#endif
+
 -- Test to see if generated names are unique
 data Lexeme = Lexeme
 
@@ -81,11 +91,12 @@ $(deriveAll ''Text.Read.Lex.Lexeme)
 data family MyType3 a b
 newtype instance MyType3 ()   b = MyType3Newtype b
 data    instance MyType3 Bool b = MyType3True | MyType3False
+data    instance MyType3 Int  b = MyType3Hash b Addr# Char# Double# Float# Int# Word#
 
-#if __GLASGOW_HASKELL__ < 707
+# if __GLASGOW_HASKELL__ < 707
 $(deriveMeta 'MyType3Newtype)
 $(deriveMeta 'MyType3True)
-#endif
+# endif
 
 # if __GLASGOW_HASKELL__ >= 705
 deriving instance Generic (MyType3 ()   b)
@@ -101,6 +112,13 @@ deriving instance Generic1 (MyType3 Bool)
 # else
 $(deriveRepresentable1 'MyType3Newtype)
 $(deriveRepresentable1 'MyType3False)
+# endif
+
+# if __GLASGOW_HASKELL__ >= 711
+deriving instance Generic (MyType3Hash Int b)
+deriving instance Generic1 (MyType3Hash Int)
+# else
+$(deriveAll0And1 'MyType3Hash)
 # endif
 #endif
 

--- a/generic-deriving.cabal
+++ b/generic-deriving.cabal
@@ -48,6 +48,9 @@ library
 
                         Generics.Deriving.TH
 
+  other-modules:        Generics.Deriving.TH.Internal
+                        Paths_generic_deriving
+
   build-depends:        base < 5, containers >= 0.1 && < 0.6, template-haskell >=2.4 && <2.12
   if impl(ghc > 7.0)
     build-depends:      ghc-prim < 1

--- a/src/Generics/Deriving/Base.hs
+++ b/src/Generics/Deriving/Base.hs
@@ -603,6 +603,7 @@ import GHC.Generics
 #endif
 
 #if __GLASGOW_HASKELL__ < 711
+import GHC.Exts ( Char(C#), Double(D#), Float(F#), Int(I#), Word(W#) )
 import GHC.Prim ( Addr#, Char#, Double#, Float#, Int#, Word# )
 #endif
 
@@ -749,21 +750,36 @@ data UAddr = UAddr { uAddr# :: Addr# }
 
 -- | Used for marking occurrences of Char#
 data UChar = UChar { uChar# :: Char# }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord)
+
+instance Show UChar where
+  showsPrec _ (UChar c) = showsPrec 0 (C# c) . showChar '#'
 
 -- | Used for marking occurrences of Double#
 data UDouble = UDouble { uDouble# :: Double# }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord)
+
+instance Show UDouble where
+  showsPrec _ (UDouble d) = showsPrec 0 (D# d) . showString "##"
 
 -- | Used for marking occurrences of Float#
 data UFloat = UFloat { uFloat# :: Float# }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord)
+
+instance Show UFloat where
+  showsPrec _ (UFloat f) = showsPrec 0 (F# f) . showChar '#'
 
 -- | Used for marking occurrences of Int#
 data UInt = UInt { uInt# :: Int# }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord)
+
+instance Show UInt where
+  showsPrec _ (UInt i) = showsPrec 0 (I# i) . showChar '#'
 
 -- | Used for marking occurrences of Word#
 data UWord = UWord { uWord# :: Word# }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord)
+
+instance Show UWord where
+  showsPrec _ (UWord w) = showsPrec 0 (W# w) . showString "##"
 #endif

--- a/src/Generics/Deriving/Base.hs
+++ b/src/Generics/Deriving/Base.hs
@@ -534,12 +534,12 @@ module Generics.Deriving.Base (
 -- of common unboxed types:
 --
 -- @
--- data 'UAddr'   = 'UAddr'   { 'uAddr#'   :: 'Addr#'   }
--- data 'UChar'   = 'UChar'   { 'uChar#'   :: 'Char#'   }
--- data 'UDouble' = 'UDouble' { 'uDouble#' :: 'Double#' }
--- data 'UFloat'  = 'UFloat'  { 'uFloat#'  :: 'Float#'  }
--- data 'UInt'    = 'UInt'    { 'uInt#'    :: 'Int#'    }
--- data 'UWord'   = 'UWord'   { 'uWord#'   :: 'Word#'   }
+-- data 'UAddr' p   = 'UAddr'   { 'uAddr#'   :: 'Addr#'   }
+-- data 'UChar' p   = 'UChar'   { 'uChar#'   :: 'Char#'   }
+-- data 'UDouble' p = 'UDouble' { 'uDouble#' :: 'Double#' }
+-- data 'UFloat' p  = 'UFloat'  { 'uFloat#'  :: 'Float#'  }
+-- data 'UInt' p    = 'UInt'    { 'uInt#'    :: 'Int#'    }
+-- data 'UWord' p   = 'UWord'   { 'uWord#'   :: 'Word#'   }
 -- @
 --
 -- The declaration
@@ -556,7 +556,7 @@ module Generics.Deriving.Base (
 --   type 'Rep' IntHash =
 --     'D1' D1IntHash
 --       ('C1' C1_0IntHash
---         ('S1' 'NoSelector' ('Rec0' 'UInt')))
+--         ('S1' 'NoSelector' 'UInt'))
 -- @
 --
 -- These data types allow users to give specific implementations of a generic
@@ -603,7 +603,6 @@ import GHC.Generics
 #endif
 
 #if __GLASGOW_HASKELL__ < 711
-import GHC.Exts ( Char(C#), Double(D#), Float(F#), Int(I#), Word(W#) )
 import GHC.Prim ( Addr#, Char#, Double#, Float#, Int#, Word# )
 #endif
 
@@ -745,41 +744,26 @@ class Generic1 f where
 
 #if __GLASGOW_HASKELL__ < 711
 -- | Used for marking occurrences of Addr#
-data UAddr = UAddr { uAddr# :: Addr# }
+data UAddr p = UAddr { uAddr# :: Addr# }
   deriving (Eq, Ord)
 
 -- | Used for marking occurrences of Char#
-data UChar = UChar { uChar# :: Char# }
-  deriving (Eq, Ord)
-
-instance Show UChar where
-  showsPrec _ (UChar c) = showsPrec 0 (C# c) . showChar '#'
+data UChar p = UChar { uChar# :: Char# }
+  deriving (Eq, Ord, Show)
 
 -- | Used for marking occurrences of Double#
-data UDouble = UDouble { uDouble# :: Double# }
-  deriving (Eq, Ord)
-
-instance Show UDouble where
-  showsPrec _ (UDouble d) = showsPrec 0 (D# d) . showString "##"
+data UDouble p = UDouble { uDouble# :: Double# }
+  deriving (Eq, Ord, Show)
 
 -- | Used for marking occurrences of Float#
-data UFloat = UFloat { uFloat# :: Float# }
-  deriving (Eq, Ord)
-
-instance Show UFloat where
-  showsPrec _ (UFloat f) = showsPrec 0 (F# f) . showChar '#'
+data UFloat p = UFloat { uFloat# :: Float# }
+  deriving (Eq, Ord, Show)
 
 -- | Used for marking occurrences of Int#
-data UInt = UInt { uInt# :: Int# }
-  deriving (Eq, Ord)
-
-instance Show UInt where
-  showsPrec _ (UInt i) = showsPrec 0 (I# i) . showChar '#'
+data UInt p = UInt { uInt# :: Int# }
+  deriving (Eq, Ord, Show)
 
 -- | Used for marking occurrences of Word#
-data UWord = UWord { uWord# :: Word# }
-  deriving (Eq, Ord)
-
-instance Show UWord where
-  showsPrec _ (UWord w) = showsPrec 0 (W# w) . showString "##"
+data UWord p = UWord { uWord# :: Word# }
+  deriving (Eq, Ord, Show)
 #endif

--- a/src/Generics/Deriving/Eq.hs
+++ b/src/Generics/Deriving/Eq.hs
@@ -57,6 +57,25 @@ instance (GEq' a, GEq' b) => GEq' (a :+: b) where
 instance (GEq' a, GEq' b) => GEq' (a :*: b) where
   geq' (a1 :*: b1) (a2 :*: b2) = geq' a1 a2 && geq' b1 b2
 
+-- Unboxed types
+instance GEq' UAddr where
+  geq' (UAddr a1) (UAddr a2)     = isTrue# (eqAddr# a1 a2)
+instance GEq' UChar where
+  geq' (UChar c1) (UChar c2)     = isTrue# (eqChar# c1 c2)
+instance GEq' UDouble where
+  geq' (UDouble d1) (UDouble d2) = isTrue# (d1 ==## d2)
+instance GEq' UFloat where
+  geq' (UFloat f1) (UFloat f2)   = isTrue# (eqFloat# f1 f2)
+instance GEq' UInt where
+  geq' (UInt i1) (UInt i2)       = isTrue# (i1 ==# i2)
+instance GEq' UWord where
+  geq' (UWord w1) (UWord w2)     = isTrue# (eqWord# w1 w2)
+
+#if __GLASGOW_HASKELL__ < 707
+isTrue# :: Bool -> Bool
+isTrue# = id
+#endif
+
 
 class GEq a where
   geq :: a -> a -> Bool
@@ -93,23 +112,4 @@ instance (GEq a) => GEq [a] where
 instance (GEq a) => GEq (Maybe a)
 instance (GEq a) => GEq [a]
 
-#endif
-
--- Unboxed types
-instance GEq UAddr where
-  geq (UAddr a1) (UAddr a2)     = isTrue# (eqAddr# a1 a2)
-instance GEq UChar where
-  geq (UChar c1) (UChar c2)     = isTrue# (eqChar# c1 c2)
-instance GEq UDouble where
-  geq (UDouble d1) (UDouble d2) = isTrue# (d1 ==## d2)
-instance GEq UFloat where
-  geq (UFloat f1) (UFloat f2)   = isTrue# (eqFloat# f1 f2)
-instance GEq UInt where
-  geq (UInt i1) (UInt i2)       = isTrue# (i1 ==# i2)
-instance GEq UWord where
-  geq (UWord w1) (UWord w2)     = isTrue# (eqWord# w1 w2)
-
-#if __GLASGOW_HASKELL__ < 707
-isTrue# :: Bool -> Bool
-isTrue# = id
 #endif

--- a/src/Generics/Deriving/Eq.hs
+++ b/src/Generics/Deriving/Eq.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
 
 #if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE DefaultSignatures #-}
@@ -27,6 +28,8 @@ module Generics.Deriving.Eq (
 import Generics.Deriving.Base
 import Generics.Deriving.Instances ()
 -- import GHC.Generics
+
+import GHC.Exts
 
 --------------------------------------------------------------------------------
 -- Generic show
@@ -55,7 +58,7 @@ instance (GEq' a, GEq' b) => GEq' (a :*: b) where
   geq' (a1 :*: b1) (a2 :*: b2) = geq' a1 a2 && geq' b1 b2
 
 
-class GEq a where 
+class GEq a where
   geq :: a -> a -> Bool
 
 
@@ -90,4 +93,23 @@ instance (GEq a) => GEq [a] where
 instance (GEq a) => GEq (Maybe a)
 instance (GEq a) => GEq [a]
 
+#endif
+
+-- Unboxed types
+instance GEq UAddr where
+  geq (UAddr a1) (UAddr a2)     = isTrue# (eqAddr# a1 a2)
+instance GEq UChar where
+  geq (UChar c1) (UChar c2)     = isTrue# (eqChar# c1 c2)
+instance GEq UDouble where
+  geq (UDouble d1) (UDouble d2) = isTrue# (d1 ==## d2)
+instance GEq UFloat where
+  geq (UFloat f1) (UFloat f2)   = isTrue# (eqFloat# f1 f2)
+instance GEq UInt where
+  geq (UInt i1) (UInt i2)       = isTrue# (i1 ==# i2)
+instance GEq UWord where
+  geq (UWord w1) (UWord w2)     = isTrue# (eqWord# w1 w2)
+
+#if __GLASGOW_HASKELL__ < 707
+isTrue# :: Bool -> Bool
+isTrue# = id
 #endif

--- a/src/Generics/Deriving/Instances.hs
+++ b/src/Generics/Deriving/Instances.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE TypeOperators #-}

--- a/src/Generics/Deriving/Instances.hs
+++ b/src/Generics/Deriving/Instances.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE TypeOperators #-}
@@ -93,12 +92,12 @@ import Generics.Deriving.Base
 #endif
 
 #if __GLASGOW_HASKELL__ < 711
-type Rep0UAddr = D1 D1UAddr (C1 C1_0UAddr (S1 S1_0_0UAddr (Rec0 UAddr)))
+type Rep0UAddr p = D1 D1UAddr (C1 C1_0UAddr (S1 S1_0_0UAddr UAddr))
 
-instance Generic UAddr where
-    type Rep UAddr = Rep0UAddr
-    from (UAddr a) = M1 (M1 (M1 (K1 (UAddr a))))
-    to (M1 (M1 (M1 (K1 a)))) = UAddr (uAddr# a)
+instance Generic (UAddr p) where
+    type Rep (UAddr p) = Rep0UAddr p
+    from (UAddr a) = M1 (M1 (M1 (UAddr a)))
+    to (M1 (M1 (M1 (UAddr a)))) = UAddr a
 
 data D1UAddr
 data C1_0UAddr
@@ -117,12 +116,12 @@ instance Selector S1_0_0UAddr where
 
 -----
 
-type Rep0UChar = D1 D1UChar (C1 C1_0UChar (S1 S1_0_0UChar (Rec0 UChar)))
+type Rep0UChar p = D1 D1UChar (C1 C1_0UChar (S1 S1_0_0UChar UChar))
 
-instance Generic UChar where
-    type Rep UChar = Rep0UChar
-    from (UChar c) = M1 (M1 (M1 (K1 (UChar c))))
-    to (M1 (M1 (M1 (K1 c)))) = UChar (uChar# c)
+instance Generic (UChar p) where
+    type Rep (UChar p) = Rep0UChar p
+    from (UChar c) = M1 (M1 (M1 (UChar c)))
+    to (M1 (M1 (M1 (UChar c)))) = UChar c
 
 data D1UChar
 data C1_0UChar
@@ -141,12 +140,12 @@ instance Selector S1_0_0UChar where
 
 -----
 
-type Rep0UDouble = D1 D1UDouble (C1 C1_0UDouble (S1 S1_0_0UDouble (Rec0 UDouble)))
+type Rep0UDouble p = D1 D1UDouble (C1 C1_0UDouble (S1 S1_0_0UDouble UDouble))
 
-instance Generic UDouble where
-    type Rep UDouble = Rep0UDouble
-    from (UDouble d) = M1 (M1 (M1 (K1 (UDouble d))))
-    to (M1 (M1 (M1 (K1 d)))) = UDouble (uDouble# d)
+instance Generic (UDouble p) where
+    type Rep (UDouble p) = Rep0UDouble p
+    from (UDouble d) = M1 (M1 (M1 (UDouble d)))
+    to (M1 (M1 (M1 (UDouble d)))) = UDouble d
 
 data D1UDouble
 data C1_0UDouble
@@ -165,12 +164,12 @@ instance Selector S1_0_0UDouble where
 
 -----
 
-type Rep0UFloat = D1 D1UFloat (C1 C1_0UFloat (S1 S1_0_0UFloat (Rec0 UFloat)))
+type Rep0UFloat p = D1 D1UFloat (C1 C1_0UFloat (S1 S1_0_0UFloat UFloat))
 
-instance Generic UFloat where
-    type Rep UFloat = Rep0UFloat
-    from (UFloat f) = M1 (M1 (M1 (K1 (UFloat f))))
-    to (M1 (M1 (M1 (K1 f)))) = UFloat (uFloat# f)
+instance Generic (UFloat p) where
+    type Rep (UFloat p) = Rep0UFloat p
+    from (UFloat f) = M1 (M1 (M1 (UFloat f)))
+    to (M1 (M1 (M1 (UFloat f)))) = UFloat f
 
 data D1UFloat
 data C1_0UFloat
@@ -189,12 +188,12 @@ instance Selector S1_0_0UFloat where
 
 -----
 
-type Rep0UInt = D1 D1UInt (C1 C1_0UInt (S1 S1_0_0UInt (Rec0 UInt)))
+type Rep0UInt p = D1 D1UInt (C1 C1_0UInt (S1 S1_0_0UInt UInt))
 
-instance Generic UInt where
-    type Rep UInt = Rep0UInt
-    from (UInt i) = M1 (M1 (M1 (K1 (UInt i))))
-    to (M1 (M1 (M1 (K1 i)))) = UInt (uInt# i)
+instance Generic (UInt p) where
+    type Rep (UInt p) = Rep0UInt p
+    from (UInt i) = M1 (M1 (M1 (UInt i)))
+    to (M1 (M1 (M1 (UInt i)))) = UInt i
 
 data D1UInt
 data C1_0UInt
@@ -213,12 +212,12 @@ instance Selector S1_0_0UInt where
 
 -----
 
-type Rep0UWord = D1 D1UWord (C1 C1_0UWord (S1 S1_0_0UWord (Rec0 UWord)))
+type Rep0UWord p = D1 D1UWord (C1 C1_0UWord (S1 S1_0_0UWord UWord))
 
-instance Generic UWord where
-    type Rep UWord = Rep0UWord
-    from (UWord w) = M1 (M1 (M1 (K1 (UWord w))))
-    to (M1 (M1 (M1 (K1 w)))) = UWord (uWord# w)
+instance Generic (UWord p) where
+    type Rep (UWord p) = Rep0UWord p
+    from (UWord w) = M1 (M1 (M1 (UWord w)))
+    to (M1 (M1 (M1 (UWord w)))) = UWord w
 
 data D1UWord
 data C1_0UWord

--- a/src/Generics/Deriving/Instances.hs
+++ b/src/Generics/Deriving/Instances.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE TypeOperators #-}
@@ -8,8 +9,16 @@
 module Generics.Deriving.Instances (
 -- Only instances from Generics.Deriving.Base
 -- and the Generic1 instances
+#if __GLASGOW_HASKELL__ < 711
+    Rep0UAddr
+  , Rep0UChar
+  , Rep0UDouble
+  , Rep0UFloat
+  , Rep0UInt
+  , Rep0UWord
+#endif
 #if __GLASGOW_HASKELL__ < 708
-    Rep0All
+  , Rep0All
   , Rep0Any
   , Rep0Arity
   , Rep0Associativity
@@ -77,8 +86,159 @@ module Generics.Deriving.Instances (
 #if __GLASGOW_HASKELL__ < 708
 import Control.Applicative
 import Data.Monoid
-import Generics.Deriving.Base
+#endif
 
+#if __GLASGOW_HASKELL__ < 711
+import Generics.Deriving.Base
+#endif
+
+#if __GLASGOW_HASKELL__ < 711
+type Rep0UAddr = D1 D1UAddr (C1 C1_0UAddr (S1 S1_0_0UAddr (Rec0 UAddr)))
+
+instance Generic UAddr where
+    type Rep UAddr = Rep0UAddr
+    from (UAddr a) = M1 (M1 (M1 (K1 (UAddr a))))
+    to (M1 (M1 (M1 (K1 a)))) = UAddr (uAddr# a)
+
+data D1UAddr
+data C1_0UAddr
+data S1_0_0UAddr
+
+instance Datatype D1UAddr where
+    datatypeName _ = "UAddr"
+    moduleName   _ = "Generics.Deriving.Base"
+
+instance Constructor C1_0UAddr where
+    conName     _ = "UAddr"
+    conIsRecord _ = True
+
+instance Selector S1_0_0UAddr where
+    selName _ = "uAddr#"
+
+-----
+
+type Rep0UChar = D1 D1UChar (C1 C1_0UChar (S1 S1_0_0UChar (Rec0 UChar)))
+
+instance Generic UChar where
+    type Rep UChar = Rep0UChar
+    from (UChar c) = M1 (M1 (M1 (K1 (UChar c))))
+    to (M1 (M1 (M1 (K1 c)))) = UChar (uChar# c)
+
+data D1UChar
+data C1_0UChar
+data S1_0_0UChar
+
+instance Datatype D1UChar where
+    datatypeName _ = "UChar"
+    moduleName   _ = "Generics.Deriving.Base"
+
+instance Constructor C1_0UChar where
+    conName     _ = "UChar"
+    conIsRecord _ = True
+
+instance Selector S1_0_0UChar where
+    selName _ = "uChar#"
+
+-----
+
+type Rep0UDouble = D1 D1UDouble (C1 C1_0UDouble (S1 S1_0_0UDouble (Rec0 UDouble)))
+
+instance Generic UDouble where
+    type Rep UDouble = Rep0UDouble
+    from (UDouble d) = M1 (M1 (M1 (K1 (UDouble d))))
+    to (M1 (M1 (M1 (K1 d)))) = UDouble (uDouble# d)
+
+data D1UDouble
+data C1_0UDouble
+data S1_0_0UDouble
+
+instance Datatype D1UDouble where
+    datatypeName _ = "UDouble"
+    moduleName   _ = "Generics.Deriving.Base"
+
+instance Constructor C1_0UDouble where
+    conName     _ = "UDouble"
+    conIsRecord _ = True
+
+instance Selector S1_0_0UDouble where
+    selName _ = "uDouble#"
+
+-----
+
+type Rep0UFloat = D1 D1UFloat (C1 C1_0UFloat (S1 S1_0_0UFloat (Rec0 UFloat)))
+
+instance Generic UFloat where
+    type Rep UFloat = Rep0UFloat
+    from (UFloat f) = M1 (M1 (M1 (K1 (UFloat f))))
+    to (M1 (M1 (M1 (K1 f)))) = UFloat (uFloat# f)
+
+data D1UFloat
+data C1_0UFloat
+data S1_0_0UFloat
+
+instance Datatype D1UFloat where
+    datatypeName _ = "UFloat"
+    moduleName   _ = "Generics.Deriving.Base"
+
+instance Constructor C1_0UFloat where
+    conName     _ = "UFloat"
+    conIsRecord _ = True
+
+instance Selector S1_0_0UFloat where
+    selName _ = "uFloat#"
+
+-----
+
+type Rep0UInt = D1 D1UInt (C1 C1_0UInt (S1 S1_0_0UInt (Rec0 UInt)))
+
+instance Generic UInt where
+    type Rep UInt = Rep0UInt
+    from (UInt i) = M1 (M1 (M1 (K1 (UInt i))))
+    to (M1 (M1 (M1 (K1 i)))) = UInt (uInt# i)
+
+data D1UInt
+data C1_0UInt
+data S1_0_0UInt
+
+instance Datatype D1UInt where
+    datatypeName _ = "UInt"
+    moduleName   _ = "Generics.Deriving.Base"
+
+instance Constructor C1_0UInt where
+    conName     _ = "UInt"
+    conIsRecord _ = True
+
+instance Selector S1_0_0UInt where
+    selName _ = "uInt#"
+
+-----
+
+type Rep0UWord = D1 D1UWord (C1 C1_0UWord (S1 S1_0_0UWord (Rec0 UWord)))
+
+instance Generic UWord where
+    type Rep UWord = Rep0UWord
+    from (UWord w) = M1 (M1 (M1 (K1 (UWord w))))
+    to (M1 (M1 (M1 (K1 w)))) = UWord (uWord# w)
+
+data D1UWord
+data C1_0UWord
+data S1_0_0UWord
+
+instance Datatype D1UWord where
+    datatypeName _ = "UWord"
+    moduleName   _ = "Generics.Deriving.Base"
+
+instance Constructor C1_0UWord where
+    conName     _ = "UWord"
+    conIsRecord _ = True
+
+instance Selector S1_0_0UWord where
+    selName _ = "uWord#"
+#endif
+
+-----
+
+#if __GLASGOW_HASKELL__ < 708
 --------------------------------------------------------------------------------
 -- Representations for base types
 --------------------------------------------------------------------------------

--- a/src/Generics/Deriving/Show.hs
+++ b/src/Generics/Deriving/Show.hs
@@ -99,6 +99,18 @@ instance (GShow' a, GShow' b) => GShow' (a :*: b) where
   -- If we have a product then it is not a nullary constructor
   isNullary _ = False
 
+-- Unboxed types
+instance GShow' UChar where
+  gshowsPrec' _ _ (UChar c)   = showsPrec 0 (C# c) . showChar '#'
+instance GShow' UDouble where
+  gshowsPrec' _ _ (UDouble d) = showsPrec 0 (D# d) . showString "##"
+instance GShow' UFloat where
+  gshowsPrec' _ _ (UFloat f)  = showsPrec 0 (F# f) . showChar '#'
+instance GShow' UInt where
+  gshowsPrec' _ _ (UInt i)    = showsPrec 0 (I# i) . showChar '#'
+instance GShow' UWord where
+  gshowsPrec' _ _ (UWord w)   = showsPrec 0 (W# w) . showString "##"
+
 
 class GShow a where
   gshowsPrec :: Int -> a -> ShowS
@@ -127,12 +139,10 @@ gshowsPrecdefault n = gshowsPrec' Pref n . from
 
 -- Base types instances
 instance GShow Char   where gshowsPrec = showsPrec
-instance GShow Double where gshowsPrec = showsPrec
 instance GShow Int    where gshowsPrec = showsPrec
 instance GShow Float  where gshowsPrec = showsPrec
 instance GShow String where gshowsPrec = showsPrec
 instance GShow Bool   where gshowsPrec = showsPrec
-instance GShow Word   where gshowsPrec = showsPrec
 
 intersperse :: a -> [a] -> [a]
 intersperse _ []    = []
@@ -144,15 +154,3 @@ instance (GShow a) => GShow [a] where
                    . foldr (.) id
                       (intersperse (showChar ',') (map (gshowsPrec 0) l))
                    . showChar ']'
-
--- Unboxed types
-instance GShow UChar where
-  gshowsPrec p (UChar c)   = gshowsPrec p (C# c)
-instance GShow UDouble where
-  gshowsPrec p (UDouble d) = gshowsPrec p (D# d)
-instance GShow UFloat where
-  gshowsPrec p (UFloat f)  = gshowsPrec p (F# f)
-instance GShow UInt where
-  gshowsPrec p (UInt i)    = gshowsPrec p (I# i)
-instance GShow UWord where
-  gshowsPrec p (UWord w)   = gshowsPrec p (W# w)

--- a/src/Generics/Deriving/Show.hs
+++ b/src/Generics/Deriving/Show.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
 #if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE DefaultSignatures #-}
 #endif
@@ -17,9 +18,10 @@ module Generics.Deriving.Show (
 
   ) where
 
-
 import Generics.Deriving.Base
 import Generics.Deriving.Instances ()
+
+import GHC.Exts
 
 --------------------------------------------------------------------------------
 -- Generic show
@@ -46,10 +48,10 @@ instance (GShow c) => GShow' (K1 i c) where
 -- No instances for P or Rec because gshow is only applicable to types of kind *
 
 instance (GShow' a, Constructor c) => GShow' (M1 C c a) where
-  gshowsPrec' _ n c@(M1 x) = 
+  gshowsPrec' _ n c@(M1 x) =
     case fixity of
-      Prefix    -> showParen (n > appPrec && not (isNullary x)) 
-                    ( showString (conName c) 
+      Prefix    -> showParen (n > appPrec && not (isNullary x))
+                    ( showString (conName c)
                     . if (isNullary x) then id else showChar ' '
                     . showBraces t (gshowsPrec' t appPrec x))
       Infix _ m -> showParen (n > m) (showBraces t (gshowsPrec' t m x))
@@ -93,12 +95,12 @@ instance (GShow' a, GShow' b) => GShow' (a :*: b) where
     gshowsPrec' t n     a . showChar ','    . gshowsPrec' t n     b
   gshowsPrec' t@Pref    n (a :*: b) =
     gshowsPrec' t (n+1) a . showChar ' '    . gshowsPrec' t (n+1) b
-  
+
   -- If we have a product then it is not a nullary constructor
   isNullary _ = False
 
 
-class GShow a where 
+class GShow a where
   gshowsPrec :: Int -> a -> ShowS
   gshows :: a -> ShowS
   gshows = gshowsPrec 0
@@ -125,10 +127,12 @@ gshowsPrecdefault n = gshowsPrec' Pref n . from
 
 -- Base types instances
 instance GShow Char   where gshowsPrec = showsPrec
+instance GShow Double where gshowsPrec = showsPrec
 instance GShow Int    where gshowsPrec = showsPrec
 instance GShow Float  where gshowsPrec = showsPrec
 instance GShow String where gshowsPrec = showsPrec
 instance GShow Bool   where gshowsPrec = showsPrec
+instance GShow Word   where gshowsPrec = showsPrec
 
 intersperse :: a -> [a] -> [a]
 intersperse _ []    = []
@@ -140,3 +144,15 @@ instance (GShow a) => GShow [a] where
                    . foldr (.) id
                       (intersperse (showChar ',') (map (gshowsPrec 0) l))
                    . showChar ']'
+
+-- Unboxed types
+instance GShow UChar where
+  gshowsPrec p (UChar c)   = gshowsPrec p (C# c)
+instance GShow UDouble where
+  gshowsPrec p (UDouble d) = gshowsPrec p (D# d)
+instance GShow UFloat where
+  gshowsPrec p (UFloat f)  = gshowsPrec p (F# f)
+instance GShow UInt where
+  gshowsPrec p (UInt i)    = gshowsPrec p (I# i)
+instance GShow UWord where
+  gshowsPrec p (UWord w)   = gshowsPrec p (W# w)

--- a/src/Generics/Deriving/TH.hs
+++ b/src/Generics/Deriving/TH.hs
@@ -423,8 +423,6 @@ mkDataInstance dv n _isNewtype =
     name    = maybe (error "Cannot fetch module name!")  id (nameModule n)
 #if __GLASGOW_HASKELL__ >= 711
     pkgName = maybe (error "Cannot fetch package name!") id (namePackage n)
-    namePackage (Name _ (NameG _ pkg _)) = Just $ pkgString pkg
-    namePackage _                        = Nothing
 #endif
 
 liftFixity :: Fixity -> Q Exp

--- a/src/Generics/Deriving/TH/Internal.hs
+++ b/src/Generics/Deriving/TH/Internal.hs
@@ -328,6 +328,13 @@ mkGD7'1_d = mkNameG_d "ghc-prim" "GHC.Generics"
 mkGD7'1_d = mkNameG_d gdPackageKey "Generics.Deriving.Base"
 #endif
 
+mkGD7'11_d :: String -> Name
+#if __GLASGOW_HASKELL__ >= 711
+mkGD7'11_d = mkNameG_d "base" "GHC.Generics"
+#else
+mkGD7'11_d = mkNameG_d gdPackageKey "Generics.Deriving.Base"
+#endif
+
 mkGD7'1_tc :: String -> Name
 #if __GLASGOW_HASKELL__ >= 705
 mkGD7'1_tc = mkNameG_tc "base" "GHC.Generics"
@@ -335,6 +342,13 @@ mkGD7'1_tc = mkNameG_tc "base" "GHC.Generics"
 mkGD7'1_tc = mkNameG_tc "ghc-prim" "GHC.Generics"
 #else
 mkGD7'1_tc = mkNameG_tc gdPackageKey "Generics.Deriving.Base"
+#endif
+
+mkGD7'11_tc :: String -> Name
+#if __GLASGOW_HASKELL__ >= 711
+mkGD7'11_tc = mkNameG_tc "base" "GHC.Generics"
+#else
+mkGD7'11_tc = mkNameG_tc gdPackageKey "Generics.Deriving.Base"
 #endif
 
 mkGD7'1_v :: String -> Name
@@ -345,6 +359,73 @@ mkGD7'1_v = mkNameG_v "ghc-prim" "GHC.Generics"
 #else
 mkGD7'1_v = mkNameG_v gdPackageKey "Generics.Deriving.Base"
 #endif
+
+mkGD7'11_v :: String -> Name
+#if __GLASGOW_HASKELL__ >= 711
+mkGD7'11_v = mkNameG_v "base" "GHC.Generics"
+#else
+mkGD7'11_v = mkNameG_v gdPackageKey "Generics.Deriving.Base"
+#endif
+
+comp1DataName :: Name
+comp1DataName = mkGD7'1_d "Comp1"
+
+infixDataName :: Name
+infixDataName = mkGD7'1_d "Infix"
+
+k1DataName :: Name
+k1DataName = mkGD7'1_d "K1"
+
+l1DataName :: Name
+l1DataName = mkGD7'1_d "L1"
+
+leftAssociativeDataName :: Name
+leftAssociativeDataName = mkGD7'1_d "LeftAssociative"
+
+m1DataName :: Name
+m1DataName = mkGD7'1_d "M1"
+
+notAssociativeDataName :: Name
+notAssociativeDataName = mkGD7'1_d "NotAssociative"
+
+par1DataName :: Name
+par1DataName = mkGD7'1_d "Par1"
+
+prefixDataName :: Name
+prefixDataName = mkGD7'1_d "Prefix"
+
+productDataName :: Name
+productDataName = mkGD7'1_d ":*:"
+
+r1DataName :: Name
+r1DataName = mkGD7'1_d "R1"
+
+rec1DataName :: Name
+rec1DataName = mkGD7'1_d "Rec1"
+
+rightAssociativeDataName :: Name
+rightAssociativeDataName = mkGD7'1_d "RightAssociative"
+
+u1DataName :: Name
+u1DataName = mkGD7'1_d "U1"
+
+uAddrDataName :: Name
+uAddrDataName = mkGD7'11_d "UAddr"
+
+uCharDataName :: Name
+uCharDataName = mkGD7'11_d "UChar"
+
+uDoubleDataName :: Name
+uDoubleDataName = mkGD7'11_d "UDouble"
+
+uFloatDataName :: Name
+uFloatDataName = mkGD7'11_d "UFloat"
+
+uIntDataName :: Name
+uIntDataName = mkGD7'11_d "UInt"
+
+uWordDataName :: Name
+uWordDataName = mkGD7'11_d "UWord"
 
 c1TypeName :: Name
 c1TypeName = mkGD7'1_tc "C1"
@@ -400,50 +481,26 @@ sumTypeName = mkGD7'1_tc ":+:"
 u1TypeName :: Name
 u1TypeName = mkGD7'1_tc "U1"
 
+uAddrTypeName :: Name
+uAddrTypeName = mkGD7'11_tc "UAddr"
+
+uCharTypeName :: Name
+uCharTypeName = mkGD7'11_tc "UChar"
+
+uDoubleTypeName :: Name
+uDoubleTypeName = mkGD7'11_tc "UDouble"
+
+uFloatTypeName :: Name
+uFloatTypeName = mkGD7'11_tc "UFloat"
+
+uIntTypeName :: Name
+uIntTypeName = mkGD7'11_tc "UInt"
+
+uWordTypeName :: Name
+uWordTypeName = mkGD7'11_tc "UWord"
+
 v1TypeName :: Name
 v1TypeName = mkGD7'1_tc "V1"
-
-comp1DataName :: Name
-comp1DataName = mkGD7'1_d "Comp1"
-
-infixDataName :: Name
-infixDataName = mkGD7'1_d "Infix"
-
-k1DataName :: Name
-k1DataName = mkGD7'1_d "K1"
-
-l1DataName :: Name
-l1DataName = mkGD7'1_d "L1"
-
-leftAssociativeDataName :: Name
-leftAssociativeDataName = mkGD7'1_d "LeftAssociative"
-
-m1DataName :: Name
-m1DataName = mkGD7'1_d "M1"
-
-notAssociativeDataName :: Name
-notAssociativeDataName = mkGD7'1_d "NotAssociative"
-
-par1DataName :: Name
-par1DataName = mkGD7'1_d "Par1"
-
-prefixDataName :: Name
-prefixDataName = mkGD7'1_d "Prefix"
-
-productDataName :: Name
-productDataName = mkGD7'1_d ":*:"
-
-r1DataName :: Name
-r1DataName = mkGD7'1_d "R1"
-
-rec1DataName :: Name
-rec1DataName = mkGD7'1_d "Rec1"
-
-rightAssociativeDataName :: Name
-rightAssociativeDataName = mkGD7'1_d "RightAssociative"
-
-u1DataName :: Name
-u1DataName = mkGD7'1_d "U1"
 
 conFixityValName :: Name
 conFixityValName = mkGD7'1_v "conFixity"
@@ -485,6 +542,24 @@ toValName = mkGD7'1_v "to"
 to1ValName :: Name
 to1ValName = mkGD7'1_v "to1"
 
+uAddrHashValName :: Name
+uAddrHashValName = mkGD7'11_v "uAddr#"
+
+uCharHashValName :: Name
+uCharHashValName = mkGD7'11_v "uChar#"
+
+uDoubleHashValName :: Name
+uDoubleHashValName = mkGD7'11_v "uDouble#"
+
+uFloatHashValName :: Name
+uFloatHashValName = mkGD7'11_v "uFloat#"
+
+uIntHashValName :: Name
+uIntHashValName = mkGD7'11_v "uInt#"
+
+uWordHashValName :: Name
+uWordHashValName = mkGD7'11_v "uWord#"
+
 unComp1ValName :: Name
 unComp1ValName = mkGD7'1_v "unComp1"
 
@@ -503,6 +578,27 @@ trueDataName = mkNameG_d "ghc-prim" "GHC.Types" "True"
 #else
 trueDataName = mkNameG_d "ghc-prim" "GHC.Bool" "True"
 #endif
+
+mkGHCPrim_tc :: String -> Name
+mkGHCPrim_tc = mkNameG_tc "ghc-prim" "GHC.Prim"
+
+addrHashTypeName :: Name
+addrHashTypeName = mkGHCPrim_tc "Addr#"
+
+charHashTypeName :: Name
+charHashTypeName = mkGHCPrim_tc "Char#"
+
+doubleHashTypeName :: Name
+doubleHashTypeName = mkGHCPrim_tc "Double#"
+
+floatHashTypeName :: Name
+floatHashTypeName = mkGHCPrim_tc "Float#"
+
+intHashTypeName :: Name
+intHashTypeName = mkGHCPrim_tc "Int#"
+
+wordHashTypeName :: Name
+wordHashTypeName = mkGHCPrim_tc "Word#"
 
 composeValName :: Name
 composeValName = mkNameG_v "base" "GHC.Base" "."

--- a/src/Generics/Deriving/TH/Internal.hs
+++ b/src/Generics/Deriving/TH/Internal.hs
@@ -1,0 +1,517 @@
+{-# LANGUAGE CPP #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Generics.Deriving.TH.Internal
+-- Copyright   :  (c) 2008--2009 Universiteit Utrecht
+-- License     :  BSD3
+--
+-- Maintainer  :  generics@haskell.org
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Template Haskell-related utilities.
+-----------------------------------------------------------------------------
+
+module Generics.Deriving.TH.Internal where
+
+import           Data.Function (on)
+import           Data.List
+import qualified Data.Map as Map
+import           Data.Map as Map (Map)
+import           Data.Maybe (fromMaybe)
+import qualified Data.Set as Set
+import           Data.Set (Set)
+
+import           Language.Haskell.TH.Lib
+import           Language.Haskell.TH.Syntax
+
+#ifndef CURRENT_PACKAGE_KEY
+import           Data.Version (showVersion)
+import           Paths_generic_deriving (version)
+#endif
+
+-------------------------------------------------------------------------------
+-- Expanding type synonyms
+-------------------------------------------------------------------------------
+
+-- | Expands all type synonyms in a type. Written by Dan Rosén in the
+-- @genifunctors@ package (licensed under BSD3).
+expandSyn :: Type -> Q Type
+expandSyn (ForallT tvs ctx t) = fmap (ForallT tvs ctx) $ expandSyn t
+expandSyn t@AppT{}            = expandSynApp t []
+expandSyn t@ConT{}            = expandSynApp t []
+expandSyn (SigT t _)          = expandSyn t   -- Ignore kind synonyms
+expandSyn t                   = return t
+
+expandSynApp :: Type -> [Type] -> Q Type
+expandSynApp (AppT t1 t2) ts = do
+    t2' <- expandSyn t2
+    expandSynApp t1 (t2':ts)
+expandSynApp (ConT n) ts | nameBase n == "[]" = return $ foldl' AppT ListT ts
+expandSynApp t@(ConT n) ts = do
+    info <- reify n
+    case info of
+        TyConI (TySynD _ tvs rhs) ->
+            let (ts', ts'') = splitAt (length tvs) ts
+                subs = mkSubst tvs ts'
+                rhs' = subst subs rhs
+             in expandSynApp rhs' ts''
+        _ -> return $ foldl' AppT t ts
+expandSynApp t ts = do
+    t' <- expandSyn t
+    return $ foldl' AppT t' ts
+
+type Subst = Map Name Type
+
+mkSubst :: [TyVarBndr] -> [Type] -> Subst
+mkSubst vs ts =
+   let vs' = map tyVarBndrToName vs
+   in Map.fromList $ zip vs' ts
+
+subst :: Subst -> Type -> Type
+subst subs (ForallT v c t) = ForallT v c $ subst subs t
+subst subs t@(VarT n)      = fromMaybe t $ Map.lookup n subs
+subst subs (AppT t1 t2)    = AppT (subst subs t1) (subst subs t2)
+subst subs (SigT t k)      = SigT (subst subs t) k
+subst _ t                  = t
+
+-------------------------------------------------------------------------------
+-- NameBase
+-------------------------------------------------------------------------------
+
+-- | A wrapper around Name which only uses the nameBase (not the entire Name)
+-- to compare for equality. For example, if you had two Names a_123 and a_456,
+-- they are not equal as Names, but they are equal as NameBases.
+--
+-- This is useful when inspecting type variables, since a type variable in an
+-- instance context may have a distinct Name from a type variable within an
+-- actual constructor declaration, but we'd want to treat them as the same
+-- if they have the same nameBase (since that's what the programmer uses to
+-- begin with).
+newtype NameBase = NameBase { getName :: Name }
+
+getNameBase :: NameBase -> String
+getNameBase = nameBase . getName
+
+instance Eq NameBase where
+    (==) = (==) `on` getNameBase
+
+instance Ord NameBase where
+    compare = compare `on` getNameBase
+
+-------------------------------------------------------------------------------
+-- Assorted utilities
+-------------------------------------------------------------------------------
+
+-- | Is the given type a type family constructor (and not a data family constructor)?
+isTyFamily :: Type -> Q Bool
+isTyFamily (ConT n) = do
+    info <- reify n
+    return $ case info of
+#if MIN_VERSION_template_haskell(2,11,0)
+         FamilyI OpenTypeFamilyD{} _       -> True
+#elif MIN_VERSION_template_haskell(2,7,0)
+         FamilyI (FamilyD TypeFam _ _ _) _ -> True
+#else
+         TyConI  (FamilyD TypeFam _ _ _)   -> True
+#endif
+#if MIN_VERSION_template_haskell(2,9,0)
+         FamilyI ClosedTypeFamilyD{} _     -> True
+#endif
+         _ -> False
+isTyFamily _ = return False
+
+-- | Construct a type via curried application.
+applyTyToTys :: Type -> [Type] -> Type
+applyTyToTys = foldl' AppT
+
+-- | Apply a type constructor name to type variable binders.
+applyTyToTvbs :: Name -> [TyVarBndr] -> Type
+applyTyToTvbs = foldl' (\a -> AppT a . VarT . tyVarBndrToName) . ConT
+
+-- | Split an applied type into its individual components. For example, this:
+--
+-- @
+-- Either Int Char
+-- @
+--
+-- would split to this:
+--
+-- @
+-- [Either, Int, Char]
+-- @
+unapplyTy :: Type -> [Type]
+unapplyTy = reverse . go
+  where
+    go :: Type -> [Type]
+    go (AppT t1 t2) = t2:go t1
+    go (SigT t _)   = go t
+    go t            = [t]
+
+-- | Split a type signature by the arrows on its spine. For example, this:
+--
+-- @
+-- (Int -> String) -> Char -> ()
+-- @
+--
+-- would split to this:
+--
+-- @
+-- [Int -> String, Char, ()]
+-- @
+uncurryTy :: Type -> [Type]
+uncurryTy (AppT (AppT ArrowT t1) t2) = t1:uncurryTy t2
+uncurryTy (SigT t _)                 = uncurryTy t
+uncurryTy t                          = [t]
+
+-- | Like uncurryType, except on a kind level.
+uncurryKind :: Kind -> [Kind]
+#if MIN_VERSION_template_haskell(2,8,0)
+uncurryKind = uncurryTy
+#else
+uncurryKind (ArrowK k1 k2) = k1:uncurryKind k2
+uncurryKind k              = [k]
+#endif
+
+canRealizeKindStar :: Kind -> Bool
+canRealizeKindStar k = case uncurryKind k of
+    [k'] -> case k' of
+#if MIN_VERSION_template_haskell(2,8,0)
+                 StarT    -> True
+                 VarT{}   -> True -- Kind k can be instantiated with *
+#else
+                 StarK    -> True
+#endif
+                 _ -> False
+    _ -> False
+
+wellKinded :: [Kind] -> Bool
+wellKinded = all canRealizeKindStar
+
+-- | Replace the Name of a TyVarBndr with one from a Type (if the Type has a Name).
+replaceTyVarName :: TyVarBndr -> Type -> TyVarBndr
+replaceTyVarName tvb            (SigT t _) = replaceTyVarName tvb t
+replaceTyVarName PlainTV{}      (VarT n)   = PlainTV  n
+replaceTyVarName (KindedTV _ k) (VarT n)   = KindedTV n k
+replaceTyVarName tvb            _          = tvb
+
+tyVarBndrToName :: TyVarBndr -> Name
+tyVarBndrToName (PlainTV  name)   = name
+tyVarBndrToName (KindedTV name _) = name
+
+tyVarBndrToNameBase :: TyVarBndr -> NameBase
+tyVarBndrToNameBase = NameBase . tyVarBndrToName
+
+tyVarBndrToKind :: TyVarBndr -> Kind
+tyVarBndrToKind PlainTV{}      = starK
+tyVarBndrToKind (KindedTV _ k) = k
+
+stripRecordNames :: Con -> Con
+stripRecordNames (RecC n f) =
+  NormalC n (map (\(_, s, t) -> (s, t)) f)
+stripRecordNames c = c
+
+-- | Checks to see if the last types in a data family instance can be safely eta-
+-- reduced (i.e., dropped), given the other types. This checks for three conditions:
+--
+-- (1) All of the dropped types are type variables
+-- (2) All of the dropped types are distinct
+-- (3) None of the remaining types mention any of the dropped types
+canEtaReduce :: [Type] -> [Type] -> Bool
+canEtaReduce remaining dropped =
+       all isTyVar dropped
+    && allDistinct nbs -- Make sure not to pass something of type [Type], since Type
+                       -- didn't have an Ord instance until template-haskell-2.10.0.0
+    && not (any (`mentionsNameBase` nbs) remaining)
+  where
+    nbs :: [NameBase]
+    nbs = map varTToNameBase dropped
+
+-- | Extract the Name from a type variable.
+varTToName :: Type -> Name
+varTToName (VarT n)   = n
+varTToName (SigT t _) = varTToName t
+varTToName _          = error "Not a type variable!"
+
+-- | Extract the NameBase from a type variable.
+varTToNameBase :: Type -> NameBase
+varTToNameBase = NameBase . varTToName
+
+-- | Is the given type a variable?
+isTyVar :: Type -> Bool
+isTyVar VarT{}     = True
+isTyVar (SigT t _) = isTyVar t
+isTyVar _          = False
+
+-- | Peel off a kind signature from a Type (if it has one).
+unSigT :: Type -> Type
+unSigT (SigT t _) = t
+unSigT t          = t
+
+-- | Peel off a kind signature from a TyVarBndr (if it has one).
+unKindedTV :: TyVarBndr -> TyVarBndr
+unKindedTV (KindedTV n _) = PlainTV n
+unKindedTV tvb            = tvb
+
+-- | Does the given type mention any of the NameBases in the list?
+mentionsNameBase :: Type -> [NameBase] -> Bool
+mentionsNameBase = go Set.empty
+  where
+    go :: Set NameBase -> Type -> [NameBase] -> Bool
+    go foralls (ForallT tvbs _ t) nbs =
+        go (foralls `Set.union` Set.fromList (map tyVarBndrToNameBase tvbs)) t nbs
+    go foralls (AppT t1 t2) nbs = go foralls t1 nbs || go foralls t2 nbs
+    go foralls (SigT t _)   nbs = go foralls t nbs
+    go foralls (VarT n)     nbs = varNb `elem` nbs && not (varNb `Set.member` foralls)
+      where
+        varNb = NameBase n
+    go _       _            _   = False
+
+-- | Are all of the items in a list (which have an ordering) distinct?
+--
+-- This uses Set (as opposed to nub) for better asymptotic time complexity.
+allDistinct :: Ord a => [a] -> Bool
+allDistinct = allDistinct' Set.empty
+  where
+    allDistinct' :: Ord a => Set a -> [a] -> Bool
+    allDistinct' uniqs (x:xs)
+        | x `Set.member` uniqs = False
+        | otherwise            = allDistinct' (Set.insert x uniqs) xs
+    allDistinct' _ _           = True
+
+trd :: (a, b, c) -> c
+trd (_,_,c) = c
+
+-- | Variant of foldr1 which returns a special element for empty lists
+foldr1' :: (a -> a -> a) -> a -> [a] -> a
+foldr1' _ x [] = x
+foldr1' _ _ [x] = x
+foldr1' f x (h:t) = f h (foldr1' f x t)
+
+-- | Extracts the name of a constructor.
+constructorName :: Con -> Name
+constructorName (NormalC name      _  ) = name
+constructorName (RecC    name      _  ) = name
+constructorName (InfixC  _    name _  ) = name
+constructorName (ForallC _    _    con) = constructorName con
+
+#if MIN_VERSION_template_haskell(2,7,0)
+-- | Extracts the constructors of a data or newtype declaration.
+dataDecCons :: Dec -> [Con]
+dataDecCons (DataInstD    _ _ _ cons _) = cons
+dataDecCons (NewtypeInstD _ _ _ con  _) = [con]
+dataDecCons _ = error "Must be a data or newtype declaration."
+#endif
+
+-------------------------------------------------------------------------------
+-- Manually quoted names
+-------------------------------------------------------------------------------
+
+-- By manually generating these names we avoid needing to use the
+-- TemplateHaskell language extension when compiling the generic-deriving library.
+-- This allows the library to be used in stage1 cross-compilers.
+
+gdPackageKey :: String
+#ifdef CURRENT_PACKAGE_KEY
+gdPackageKey = CURRENT_PACKAGE_KEY
+#else
+gdPackageKey = "generic-deriving-" ++ showVersion version
+#endif
+
+mkGD7'1_d :: String -> Name
+#if __GLASGOW_HASKELL__ >= 705
+mkGD7'1_d = mkNameG_d "base" "GHC.Generics"
+#elif __GLASGOW_HASKELL__ >= 701
+mkGD7'1_d = mkNameG_d "ghc-prim" "GHC.Generics"
+#else
+mkGD7'1_d = mkNameG_d gdPackageKey "Generics.Deriving.Base"
+#endif
+
+mkGD7'1_tc :: String -> Name
+#if __GLASGOW_HASKELL__ >= 705
+mkGD7'1_tc = mkNameG_tc "base" "GHC.Generics"
+#elif __GLASGOW_HASKELL__ >= 701
+mkGD7'1_tc = mkNameG_tc "ghc-prim" "GHC.Generics"
+#else
+mkGD7'1_tc = mkNameG_tc gdPackageKey "Generics.Deriving.Base"
+#endif
+
+mkGD7'1_v :: String -> Name
+#if __GLASGOW_HASKELL__ >= 705
+mkGD7'1_v = mkNameG_v "base" "GHC.Generics"
+#elif __GLASGOW_HASKELL__ >= 701
+mkGD7'1_v = mkNameG_v "ghc-prim" "GHC.Generics"
+#else
+mkGD7'1_v = mkNameG_v gdPackageKey "Generics.Deriving.Base"
+#endif
+
+c1TypeName :: Name
+c1TypeName = mkGD7'1_tc "C1"
+
+composeTypeName :: Name
+composeTypeName = mkGD7'1_tc ":.:"
+
+constructorTypeName :: Name
+constructorTypeName = mkGD7'1_tc "Constructor"
+
+d1TypeName :: Name
+d1TypeName = mkGD7'1_tc "D1"
+
+genericTypeName :: Name
+genericTypeName = mkGD7'1_tc "Generic"
+
+generic1TypeName :: Name
+generic1TypeName = mkGD7'1_tc "Generic1"
+
+datatypeTypeName :: Name
+datatypeTypeName = mkGD7'1_tc "Datatype"
+
+noSelectorTypeName :: Name
+noSelectorTypeName = mkGD7'1_tc "NoSelector"
+
+par1TypeName :: Name
+par1TypeName = mkGD7'1_tc "Par1"
+
+productTypeName :: Name
+productTypeName = mkGD7'1_tc ":*:"
+
+rec0TypeName :: Name
+rec0TypeName = mkGD7'1_tc "Rec0"
+
+rec1TypeName :: Name
+rec1TypeName = mkGD7'1_tc "Rec1"
+
+repTypeName :: Name
+repTypeName = mkGD7'1_tc "Rep"
+
+rep1TypeName :: Name
+rep1TypeName = mkGD7'1_tc "Rep1"
+
+s1TypeName :: Name
+s1TypeName = mkGD7'1_tc "S1"
+
+selectorTypeName :: Name
+selectorTypeName = mkGD7'1_tc "Selector"
+
+sumTypeName :: Name
+sumTypeName = mkGD7'1_tc ":+:"
+
+u1TypeName :: Name
+u1TypeName = mkGD7'1_tc "U1"
+
+v1TypeName :: Name
+v1TypeName = mkGD7'1_tc "V1"
+
+comp1DataName :: Name
+comp1DataName = mkGD7'1_d "Comp1"
+
+infixDataName :: Name
+infixDataName = mkGD7'1_d "Infix"
+
+k1DataName :: Name
+k1DataName = mkGD7'1_d "K1"
+
+l1DataName :: Name
+l1DataName = mkGD7'1_d "L1"
+
+leftAssociativeDataName :: Name
+leftAssociativeDataName = mkGD7'1_d "LeftAssociative"
+
+m1DataName :: Name
+m1DataName = mkGD7'1_d "M1"
+
+notAssociativeDataName :: Name
+notAssociativeDataName = mkGD7'1_d "NotAssociative"
+
+par1DataName :: Name
+par1DataName = mkGD7'1_d "Par1"
+
+prefixDataName :: Name
+prefixDataName = mkGD7'1_d "Prefix"
+
+productDataName :: Name
+productDataName = mkGD7'1_d ":*:"
+
+r1DataName :: Name
+r1DataName = mkGD7'1_d "R1"
+
+rec1DataName :: Name
+rec1DataName = mkGD7'1_d "Rec1"
+
+rightAssociativeDataName :: Name
+rightAssociativeDataName = mkGD7'1_d "RightAssociative"
+
+u1DataName :: Name
+u1DataName = mkGD7'1_d "U1"
+
+conFixityValName :: Name
+conFixityValName = mkGD7'1_v "conFixity"
+
+conIsRecordValName :: Name
+conIsRecordValName = mkGD7'1_v "conIsRecord"
+
+conNameValName :: Name
+conNameValName = mkGD7'1_v "conName"
+
+datatypeNameValName :: Name
+datatypeNameValName = mkGD7'1_v "datatypeName"
+
+#if __GLASGOW_HASKELL__ >= 708
+isNewtypeValName :: Name
+isNewtypeValName = mkGD7'1_v "isNewtype"
+#endif
+
+fromValName :: Name
+fromValName = mkGD7'1_v "from"
+
+from1ValName :: Name
+from1ValName = mkGD7'1_v "from1"
+
+moduleNameValName :: Name
+moduleNameValName = mkGD7'1_v "moduleName"
+
+#if __GLASGOW_HASKELL__ >= 711
+packageNameValName :: Name
+packageNameValName = mkGD7'1_v "packageName"
+#endif
+
+selNameValName :: Name
+selNameValName = mkGD7'1_v "selName"
+
+toValName :: Name
+toValName = mkGD7'1_v "to"
+
+to1ValName :: Name
+to1ValName = mkGD7'1_v "to1"
+
+unComp1ValName :: Name
+unComp1ValName = mkGD7'1_v "unComp1"
+
+unK1ValName :: Name
+unK1ValName = mkGD7'1_v "unK1"
+
+unPar1ValName :: Name
+unPar1ValName = mkGD7'1_v "unPar1"
+
+unRec1ValName :: Name
+unRec1ValName = mkGD7'1_v "unRec1"
+
+trueDataName :: Name
+#if __GLASGOW_HASKELL__ >= 701
+trueDataName = mkNameG_d "ghc-prim" "GHC.Types" "True"
+#else
+trueDataName = mkNameG_d "ghc-prim" "GHC.Bool" "True"
+#endif
+
+composeValName :: Name
+composeValName = mkNameG_v "base" "GHC.Base" "."
+
+errorValName :: Name
+errorValName = mkNameG_v "base" "GHC.Err" "error"
+
+fmapValName :: Name
+fmapValName = mkNameG_v "base" "GHC.Base" "fmap"
+
+undefinedValName :: Name
+undefinedValName = mkNameG_v "base" "GHC.Err" "undefined"

--- a/src/Generics/Deriving/TH/Internal.hs
+++ b/src/Generics/Deriving/TH/Internal.hs
@@ -19,7 +19,6 @@ import           Data.Function (on)
 import           Data.List
 import qualified Data.Map as Map
 import           Data.Map as Map (Map)
-import           Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
 import           Data.Set (Set)
 
@@ -71,7 +70,7 @@ mkSubst vs ts =
 
 subst :: Subst -> Type -> Type
 subst subs (ForallT v c t) = ForallT v c $ subst subs t
-subst subs t@(VarT n)      = fromMaybe t $ Map.lookup n subs
+subst subs t@(VarT n)      = Map.findWithDefault t n subs
 subst subs (AppT t1 t2)    = AppT (subst subs t1) (subst subs t2)
 subst subs (SigT t k)      = SigT (subst subs t) k
 subst _ t                  = t


### PR DESCRIPTION
This pull request does the following:

* [`Phab:D1239`](https://phabricator.haskell.org/D1239) upgraded GHC generics to be able to recognize certain unlifted types. These changes copy over the API changes to `Generics.Deriving.Base`, and backport `Generic` instances for `URec` in `Generics.Deriving.Instances`.
* Updates `Generics.Deriving.TH` to be able to derive `Generic(1)` for data types with `Addr#`, `Char#`, etc. as arguments. The module was also refactored to build without the use of the `-XTemplateHaskell` extension, which allows `generic-deriving` to be built on stage-1 compilers.
* Adds `GEq'` and `GShow'` instances for `URec` to mimic how `deriving Eq` and `deriving Show` work for unlifted types in GHC.
* Adds some tests to `examples/Examples.hs`.