### PR TITLE
Backport typelits machinery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# next
+* On GHC 7.11 and up, `Generics.Deriving.TH` uses the new type literal-based
+  machinery
+
 # 1.9.0
 * Allow deriving of Generic1 using Template Haskell
 * Allow deriving of Generic(1) for data families

--- a/examples/Examples.hs
+++ b/examples/Examples.hs
@@ -1,20 +1,26 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DatatypeContexts #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE DatatypeContexts #-}
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 #if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE DeriveGeneric #-}
 #endif
+
+#if __GLASGOW_HASKELL__ >= 711
+{-# LANGUAGE DataKinds #-}
+#endif
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Main (

--- a/generic-deriving.cabal
+++ b/generic-deriving.cabal
@@ -59,7 +59,7 @@ library
 
   other-modules:        Generics.Deriving.TH.Internal
                         Paths_generic_deriving
-  if impl(ghc >= 8.0)
+  if impl(ghc >= 7.11)
     other-modules:      Generics.Deriving.TH.Post711
   else
     other-modules:      Generics.Deriving.TH.Pre711

--- a/generic-deriving.cabal
+++ b/generic-deriving.cabal
@@ -59,6 +59,10 @@ library
 
   other-modules:        Generics.Deriving.TH.Internal
                         Paths_generic_deriving
+  if impl(ghc >= 8.0)
+    other-modules:      Generics.Deriving.TH.Post711
+  else
+    other-modules:      Generics.Deriving.TH.Pre711
 
   build-depends:        base < 5
                       , containers       >= 0.1 && < 0.6

--- a/src/Generics/Deriving/Enum.hs
+++ b/src/Generics/Deriving/Enum.hs
@@ -183,8 +183,10 @@ instance GEnum (f a) => GEnum (Alt f a) where
 instance GEnum Any where
   genum = genumDefault
 
+#if __GLASGOW_HASKELL__ < 711
 instance GEnum Arity where
   genum = genumDefault
+#endif
 
 instance GEnum Associativity where
   genum = genumDefault
@@ -573,10 +575,12 @@ instance GIx Any where
   index   = indexDefault
   inRange = inRangeDefault
 
+#if __GLASGOW_HASKELL__ < 711
 instance GIx Arity where
   range   = rangeDefault
   index   = indexDefault
   inRange = inRangeDefault
+#endif
 
 instance GIx Associativity where
   range   = rangeDefault

--- a/src/Generics/Deriving/Eq.hs
+++ b/src/Generics/Deriving/Eq.hs
@@ -160,8 +160,10 @@ instance GEq (f a) => GEq (Alt f a) where
 instance GEq Any where
   geq = geqdefault
 
+#if __GLASGOW_HASKELL__ < 711
 instance GEq Arity where
   geq = geqdefault
+#endif
 
 instance GEq Associativity where
   geq = geqdefault

--- a/src/Generics/Deriving/Show.hs
+++ b/src/Generics/Deriving/Show.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
@@ -103,6 +104,8 @@ instance (GShow' a, Constructor c) => GShow' (M1 C c a) where
             showBraces Tup     p = showChar '(' . p . showChar ')'
             showBraces Pref    p = p
             showBraces (Inf _) p = p
+            
+            conIsTuple :: C1 c f p -> Bool
             conIsTuple y = tupleName (conName y) where
               tupleName ('(':',':_) = True
               tupleName _           = False
@@ -220,8 +223,10 @@ instance GShow (f a) => GShow (Alt f a) where
 instance GShow Any where
   gshowsPrec = gshowsPrecdefault
 
+#if __GLASGOW_HASKELL__ < 711
 instance GShow Arity where
   gshowsPrec = gshowsPrecdefault
+#endif
 
 instance GShow Associativity where
   gshowsPrec = gshowsPrecdefault

--- a/src/Generics/Deriving/TH.hs
+++ b/src/Generics/Deriving/TH.hs
@@ -87,8 +87,6 @@ module Generics.Deriving.TH (
     , makeTo1
   ) where
 
-import           Data.Char (isAlphaNum, ord)
-import           Data.List
 #if __GLASGOW_HASKELL__ >= 708 && __GLASGOW_HASKELL__ < 710
 import qualified Data.Map as Map
 import           Data.Map as Map (Map)
@@ -99,10 +97,13 @@ import           Data.Set (Set)
 #endif
 
 import           Generics.Deriving.TH.Internal
+#if __GLASGOW_HASKELL__ >= 711
+import           Generics.Deriving.TH.Post711
+#else
+import           Generics.Deriving.TH.Pre711
+#endif
 
 import           Language.Haskell.TH.Lib
-import           Language.Haskell.TH.Syntax (Name(..), NameFlavour(..), Lift(..),
-                                            modString, pkgString)
 import           Language.Haskell.TH
 
 -- | Given the names of a generic class, a type to instantiate, a function in
@@ -146,29 +147,6 @@ deriveAll0And1 n =
      c <- deriveRepresentable1 n
      return (a ++ b ++ c)
 
--- | Given the type and the name (as string) for the type to derive,
--- generate the 'Data' instance, the 'Constructor' instances, and the 'Selector'
--- instances.
-deriveMeta :: Name -> Q [Dec]
-deriveMeta n =
-  do a <- deriveData n
-     b <- deriveConstructors n
-     c <- deriveSelectors n
-     return (a ++ b ++ c)
-
--- | Given a datatype name, derive a datatype and instance of class 'Datatype'.
-deriveData :: Name -> Q [Dec]
-deriveData = dataInstance
-
--- | Given a datatype name, derive datatypes and
--- instances of class 'Constructor'.
-deriveConstructors :: Name -> Q [Dec]
-deriveConstructors = constrInstance
-
--- | Given a datatype name, derive datatypes and instances of class 'Selector'.
-deriveSelectors :: Name -> Q [Dec]
-deriveSelectors = selectInstance
-
 -- | Given the type and the name (as string) for the Representable0 type
 -- synonym to derive, generate the 'Representable0' instance.
 deriveRepresentable0 :: Name -> Q [Dec]
@@ -198,7 +176,7 @@ deriveRep1 = deriveRepCommon 1
 deriveRepCommon :: Int -> Name -> Q [Dec]
 deriveRepCommon arity n = do
   i <- reifyDataInfo n
-  let (name, _, allTvbs, cons, dv) = either error id i
+  let (name, isNT, allTvbs, cons, dv) = either error id i
       (tvbs, _, gk) = buildTypeInstance arity name allTvbs cons dv
 
   fmap (:[]) $ tySynD (genRepName arity dv name)
@@ -206,7 +184,7 @@ deriveRepCommon arity n = do
                                             -- the TyVarBndrs in a type synonym
                                             -- declaration, so we don't need to
                                             -- splice them explicitly
-                      (repType gk dv name cons)
+                      (repType gk dv name isNT cons)
 
 deriveInst :: Name -> Q [Dec]
 deriveInst = deriveInstCommon genericTypeName repTypeName 0 fromValName toValName
@@ -309,54 +287,6 @@ makeFunCommon maker arity n = do
       (_, _, gk) = buildTypeInstance arity name allTvbs cons dv
   mkCaseExp gk name cons maker
 
-dataInstance :: Name -> Q [Dec]
-dataInstance n = do
-  i <- reifyDataInfo n
-  case i of
-    Left  _                    -> return []
-    Right (n', isNT, _, _, dv) -> mkInstance n' dv isNT
-  where
-    mkInstance n' dv isNT = do
-      ds <- mkDataData dv n'
-      is <- mkDataInstance dv n' isNT
-      return $ [ds,is]
-
-constrInstance :: Name -> Q [Dec]
-constrInstance n = do
-  i <- reifyDataInfo n
-  case i of
-    Left  _               -> return []
-    Right (n', _, _, cs, dv) -> mkInstance n' cs dv
-  where
-    mkInstance n' cs dv = do
-      ds <- mapM (mkConstrData dv n') cs
-      is <- mapM (mkConstrInstance dv n') cs
-      return $ ds ++ is
-
-selectInstance :: Name -> Q [Dec]
-selectInstance n = do
-  i <- reifyDataInfo n
-  case i of
-    Left  _               -> return []
-    Right (n', _, _, cs, dv) -> mkInstance n' cs dv
-  where
-    mkInstance n' cs dv = do
-      ds <- mapM (mkSelectData dv n') cs
-      is <- mapM (mkSelectInstance dv n') cs
-      return $ concat (ds ++ is)
-
-genName :: DataVariety -> [Name] -> Name
-genName dv ns = mkName
-              . showsDataVariety dv
-              . intercalate "_"
-              . consQualName
-              $ map (sanitizeName . nameBase) ns
-  where
-    consQualName :: [String] -> [String]
-    consQualName = case ns of
-        []  -> id
-        n:_ -> (showNameQual n :)
-
 genRepName :: Int -> DataVariety -> Name -> Name
 genRepName arity dv n = mkName
                       . showsDataVariety dv
@@ -365,112 +295,9 @@ genRepName arity dv n = mkName
                       . sanitizeName
                       $ nameBase n
 
-showsDataVariety :: DataVariety -> ShowS
-showsDataVariety dv = (++ '_':label dv)
-  where
-    label DataPlain        = "Plain"
-    label (DataFamily n _) = "Family_" ++ sanitizeName (nameBase n)
-
-showNameQual :: Name -> String
-showNameQual = sanitizeName . showQual
-  where
-    showQual (Name _ (NameQ m))       = modString m
-    showQual (Name _ (NameG _ pkg m)) = pkgString pkg ++ ":" ++ modString m
-    showQual _                        = ""
-
--- | Credit to Víctor López Juan for this trick
-sanitizeName :: String -> String
-sanitizeName nb = 'N':(
-    nb >>= \x -> case x of
-      c | isAlphaNum c || c == '\''-> [c]
-      '_' -> "__"
-      c   -> "_" ++ show (ord c))
-
-mkDataData :: DataVariety -> Name -> Q Dec
-mkDataData dv n = dataD (cxt []) (genName dv [n]) [] [] []
-
-mkConstrData :: DataVariety -> Name -> Con -> Q Dec
-mkConstrData dv dt (NormalC n _) =
-  dataD (cxt []) (genName dv [dt, n]) [] [] []
-mkConstrData dv dt r@(RecC _ _) =
-  mkConstrData dv dt (stripRecordNames r)
-mkConstrData dv dt (InfixC t1 n t2) =
-  mkConstrData dv dt (NormalC n [t1,t2])
-mkConstrData _ _ (ForallC _ _ con) = forallCError con
-
-mkSelectData :: DataVariety -> Name -> Con -> Q [Dec]
-mkSelectData dv dt (RecC n fs) = return (map one fs)
-  where one (f, _, _) = DataD [] (genName dv [dt, n, f]) [] [] []
-mkSelectData _ _ _ = return []
-
-
-mkDataInstance :: DataVariety -> Name -> Bool -> Q Dec
-mkDataInstance dv n _isNewtype =
-  instanceD (cxt []) (appT (conT datatypeTypeName) (conT $ genName dv [n])) $
-    [ funD datatypeNameValName [clause [wildP] (normalB (stringE (nameBase n))) []]
-    , funD moduleNameValName   [clause [wildP] (normalB (stringE name)) []]
-#if __GLASGOW_HASKELL__ >= 711
-    , funD packageNameValName  [clause [wildP] (normalB (stringE pkgName)) []]
-#endif
-    ]
-#if __GLASGOW_HASKELL__ >= 708
- ++ if _isNewtype
-       then [funD isNewtypeValName [clause [wildP] (normalB (conE trueDataName)) []]]
-       else []
-#endif
-  where
-    name    = maybe (error "Cannot fetch module name!")  id (nameModule n)
-#if __GLASGOW_HASKELL__ >= 711
-    pkgName = maybe (error "Cannot fetch package name!") id (namePackage n)
-#endif
-
-liftFixity :: Fixity -> Q Exp
-liftFixity (Fixity n a) = conE infixDataName
-    `appE` liftAssociativity a
-    `appE` lift n
-
-liftAssociativity :: FixityDirection -> Q Exp
-liftAssociativity InfixL = conE leftAssociativeDataName
-liftAssociativity InfixR = conE rightAssociativeDataName
-liftAssociativity InfixN = conE notAssociativeDataName
-
-mkConstrInstance :: DataVariety -> Name -> Con -> Q Dec
-mkConstrInstance dv dt (NormalC n _) = mkConstrInstanceWith dv dt n []
-mkConstrInstance dv dt (RecC    n _) = mkConstrInstanceWith dv dt n
-      [ funD conIsRecordValName [clause [wildP] (normalB (conE trueDataName)) []]]
-mkConstrInstance dv dt (InfixC _ n _) =
-    do
-      i <- reify n
-#if __GLASGOW_HASKELL__ >= 711
-      fi <- case i of
-                 DataConI{} -> reifyFixity n
-                 _ -> error $ "Not a data constructor name: " ++ show n
-#else
-      let fi = case i of
-                 DataConI _ _ _ f -> f
-                 _ -> error $ "Not a data constructor name: " ++ show n
-#endif
-      instanceD (cxt []) (appT (conT constructorTypeName) (conT $ genName dv [dt, n]))
-        [funD conNameValName   [clause [wildP] (normalB (stringE (nameBase n))) []],
-         funD conFixityValName [clause [wildP] (normalB (liftFixity fi)) []]]
-mkConstrInstance _ _ (ForallC _ _ con) = forallCError con
-
-mkConstrInstanceWith :: DataVariety -> Name -> Name -> [Q Dec] -> Q Dec
-mkConstrInstanceWith dv dt n extra =
-  instanceD (cxt []) (appT (conT constructorTypeName) (conT $ genName dv [dt, n]))
-    (funD conNameValName [clause [wildP] (normalB (stringE (nameBase n))) []] : extra)
-
-mkSelectInstance :: DataVariety -> Name -> Con -> Q [Dec]
-mkSelectInstance dv dt (RecC n fs) = return (map one fs) where
-  one (f, _, _) =
-    InstanceD ([]) (AppT (ConT selectorTypeName) (ConT $ genName dv [dt, n, f]))
-      [FunD selNameValName [Clause [WildP]
-        (NormalB (LitE (StringL (nameBase f)))) []]]
-mkSelectInstance _ _ _ = return []
-
-repType :: GenericKind -> DataVariety -> Name -> [Con] -> Q Type
-repType gk dv dt cs =
-    conT d1TypeName `appT` (conT $ genName dv [dt]) `appT`
+repType :: GenericKind -> DataVariety -> Name -> Bool -> [Con] -> Q Type
+repType gk dv dt isNT cs =
+    conT d1TypeName `appT` mkMetaDataType dv dt isNT `appT`
       foldr1' sum' (conT v1TypeName)
         (map (repCon gk dv dt) cs)
   where
@@ -479,17 +306,17 @@ repType gk dv dt cs =
 
 repCon :: GenericKind -> DataVariety -> Name -> Con -> Q Type
 repCon _ dv dt (NormalC n []) =
-    conT c1TypeName `appT` (conT $ genName dv [dt, n]) `appT`
-     (conT s1TypeName `appT` conT noSelectorTypeName `appT` conT u1TypeName)
+    conT c1TypeName `appT` mkMetaConsType dv dt n False `appT`
+     (conT s1TypeName `appT` mkMetaNoSelType `appT` conT u1TypeName)
 repCon gk dv dt (NormalC n fs) =
-    conT c1TypeName `appT` (conT $ genName dv [dt, n]) `appT`
+    conT c1TypeName `appT` mkMetaConsType dv dt n False `appT`
      (foldr1 prod (map (repField gk . snd) fs)) where
     prod :: Q Type -> Q Type -> Q Type
     prod a b = conT productTypeName `appT` a `appT` b
 repCon _ dv dt (RecC n []) =
-    conT c1TypeName `appT` (conT $ genName dv [dt, n]) `appT` conT u1TypeName
+    conT c1TypeName `appT` mkMetaConsType dv dt n True `appT` conT u1TypeName
 repCon gk dv dt (RecC n fs) =
-    conT c1TypeName `appT` (conT $ genName dv [dt, n]) `appT`
+    conT c1TypeName `appT` mkMetaConsType dv dt n True `appT`
       (foldr1 prod (map (repField' gk dv dt n) fs)) where
     prod :: Q Type -> Q Type -> Q Type
     prod a b = conT productTypeName `appT` a `appT` b
@@ -497,12 +324,12 @@ repCon gk dv dt (InfixC t1 n t2)  = repCon gk dv dt (NormalC n [t1,t2])
 repCon _  _  _  (ForallC _ _ con) = forallCError con
 
 repField :: GenericKind -> Type -> Q Type
-repField gk t = conT s1TypeName `appT` conT noSelectorTypeName `appT`
+repField gk t = conT s1TypeName `appT` mkMetaNoSelType `appT`
                    (repFieldArg gk =<< expandSyn t)
 
 repField' :: GenericKind -> DataVariety -> Name -> Name -> (Name, Strict, Type) -> Q Type
 repField' gk dv dt ns (f, _, t) = conT s1TypeName
-    `appT` conT (genName dv [dt, ns, f])
+    `appT` mkMetaSelType dv dt ns f
     `appT` (repFieldArg gk =<< expandSyn t)
 
 repFieldArg :: GenericKind -> Type -> Q Type
@@ -736,72 +563,6 @@ unboxedRepNames ty
   | ty == ConT wordHashTypeName   = Just (uWordTypeName,   uWordDataName,   uWordHashValName)
   | otherwise                     = Nothing
 
--- | Boilerplate for top level splices.
---
--- The given Name must meet one of two criteria:
---
--- 1. It must be the name of a type constructor of a plain data type or newtype.
--- 2. It must be the name of a data family instance or newtype instance constructor.
---
--- Any other value will result in an exception.
-reifyDataInfo :: Name
-              -> Q (Either String (Name, Bool, [TyVarBndr], [Con], DataVariety))
-reifyDataInfo name = do
-  info <- reify name
-  case info of
-    TyConI dec ->
-      return $ case dec of
-        DataD    ctxt _ tvbs cons _ -> Right $
-          checkDataContext name ctxt (name, False, tvbs, cons, DataPlain)
-        NewtypeD ctxt _ tvbs con  _ -> Right $
-          checkDataContext name ctxt (name, True, tvbs, [con], DataPlain)
-        TySynD{} -> Left $ ns ++ "Type synonyms are not supported."
-        _        -> Left $ ns ++ "Unsupported type: " ++ show dec
-#if MIN_VERSION_template_haskell(2,7,0)
-# if MIN_VERSION_template_haskell(2,11,0)
-    DataConI _ _ parentName   -> do
-# else
-    DataConI _ _ parentName _ -> do
-# endif
-      parentInfo <- reify parentName
-      return $ case parentInfo of
-# if MIN_VERSION_template_haskell(2,11,0)
-        FamilyI (DataFamilyD _ tvbs _) decs ->
-# else
-        FamilyI (FamilyD DataFam _ tvbs _) decs ->
-# endif
-          -- This isn't total, but the API requires that the data family instance have
-          -- at least one constructor anyways, so this will always succeed.
-          let instDec = flip find decs $ any ((name ==) . constructorName) . dataDecCons
-           in case instDec of
-                Just (DataInstD    ctxt _ instTys cons _) -> Right $
-                  checkDataContext parentName ctxt
-                    (parentName, False, tvbs, cons, DataFamily (constructorName $ head cons) instTys)
-                Just (NewtypeInstD ctxt _ instTys con  _) -> Right $
-                  checkDataContext parentName ctxt
-                    (parentName, True, tvbs, [con], DataFamily (constructorName con) instTys)
-                _ -> Left $ ns ++
-                  "Could not find data or newtype instance constructor."
-        _ -> Left $ ns ++ "Data constructor " ++ show name ++
-          " is not from a data family instance constructor."
-# if MIN_VERSION_template_haskell(2,11,0)
-    FamilyI DataFamilyD{} _ ->
-# else
-    FamilyI (FamilyD DataFam _ _ _) _ ->
-# endif
-      return . Left $
-        ns ++ "Cannot use a data family name. Use a data family instance constructor instead."
-    _ -> return . Left $ ns ++ "The name must be of a plain data type constructor, "
-                            ++ "or a data family instance constructor."
-#else
-    DataConI{} -> return . Left $ ns ++ "Cannot use a data constructor."
-        ++ "\n\t(Note: if you are trying to derive for a data family instance, use GHC >= 7.4 instead.)"
-    _          -> return . Left $ ns ++ "The name must be of a plain type constructor."
-#endif
-  where
-    ns :: String
-    ns = "Generics.Deriving.TH.reifyDataInfo: "
-
 -- | Deduces the non-eta-reduced type variables, the instance type, the GenericKind
 -- value to use for a Generic(1) instance.
 buildTypeInstance :: Int
@@ -998,46 +759,6 @@ ground (VarT n)     nb = NameBase n /= nb
 ground ForallT{}    _  = rankNError
 ground _            _  = True
 
--- | One of the last type variables cannot be eta-reduced (see the canEtaReduce
--- function for the criteria it would have to meet).
-etaReductionError :: Type -> a
-etaReductionError instanceType = error $
-  "Cannot eta-reduce to an instance of form \n\tinstance (...) => "
-  ++ pprint instanceType
-
--- | Either the given data type doesn't have enough type variables, or one of
--- the type variables to be eta-reduced cannot realize kind *.
-derivingKindError :: Name -> a
-derivingKindError tyConName = error
-  . showString "Cannot derive well-kinded instance of form ‘Generic1 "
-  . showParen True
-    ( showString (nameBase tyConName)
-    . showString " ..."
-    )
-  . showString "‘\n\tClass Generic1 expects an argument of kind * -> *"
-  $ ""
-
-outOfPlaceTyVarError :: a
-outOfPlaceTyVarError = error $
-    "Type applied to an argument involving the last parameter is not of kind * -> *"
-
--- | Deriving Generic(1) doesn't work with ExistentialQuantification
-forallCError :: Con -> a
-forallCError con = error $
-  nameBase (constructorName con) ++ " must be a vanilla data constructor"
-
--- | Cannot have a constructor argument of form (forall a1 ... an. <type>)
--- when deriving Generic(1)
-rankNError :: a
-rankNError = error "Cannot have polymorphic arguments"
-
--- | One cannot derive Generic(1) instance for anything that uses DatatypeContexts,
--- so check to make sure the Cxt field of a datatype is null.
-checkDataContext :: Name -> Cxt -> a -> a
-checkDataContext _        [] x = x
-checkDataContext dataName _  _ = error $
-  nameBase dataName ++ " must not have a datatype context"
-
 -- | Indicates whether Generic (Gen0) or Generic1 (Gen1) is being derived. Gen1
 -- bundles the Name of the last type parameter.
 data GenericKind = Gen0 | Gen1 NameBase
@@ -1047,9 +768,3 @@ genericKindFromArity :: Int -> [NameBase] -> GenericKind
 genericKindFromArity 0 _   = Gen0
 genericKindFromArity 1 nbs = Gen1 $ head nbs
 genericKindFromArity _ _   = error "Invalid arity"
-
--- | Indicates whether Generic(1) is being derived for a plain data type (DataPlain)
--- or a data family instance (DataFamily). DataFamily bundles the Name of the data
--- family instance's first constructor (for Name-generation purposes) and the types
--- used to instantiate the instance.
-data DataVariety = DataPlain | DataFamily Name [Type]

--- a/src/Generics/Deriving/TH/Internal.hs
+++ b/src/Generics/Deriving/TH/Internal.hs
@@ -527,11 +527,6 @@ from1ValName = mkGD7'1_v "from1"
 moduleNameValName :: Name
 moduleNameValName = mkGD7'1_v "moduleName"
 
-#if __GLASGOW_HASKELL__ >= 711
-packageNameValName :: Name
-packageNameValName = mkGD7'1_v "packageName"
-#endif
-
 selNameValName :: Name
 selNameValName = mkGD7'1_v "selName"
 
@@ -610,3 +605,26 @@ fmapValName = mkNameG_v "base" "GHC.Base" "fmap"
 
 undefinedValName :: Name
 undefinedValName = mkNameG_v "base" "GHC.Err" "undefined"
+
+#if __GLASGOW_HASKELL__ >= 711
+infixIDataName :: Name
+infixIDataName = mkGD7'11_d "InfixI"
+
+metaConsDataName :: Name
+metaConsDataName = mkGD7'11_d "MetaCons"
+
+metaDataDataName :: Name
+metaDataDataName = mkGD7'11_d "MetaData"
+
+metaNoSelDataName :: Name
+metaNoSelDataName = mkGD7'11_d "MetaNoSel"
+
+metaSelDataName :: Name
+metaSelDataName = mkGD7'11_d "MetaSel"
+
+prefixIDataName :: Name
+prefixIDataName = mkGD7'11_d "PrefixI"
+
+packageNameValName :: Name
+packageNameValName = mkGD7'1_v "packageName"
+#endif

--- a/src/Generics/Deriving/TH/Internal.hs
+++ b/src/Generics/Deriving/TH/Internal.hs
@@ -15,6 +15,7 @@
 
 module Generics.Deriving.TH.Internal where
 
+import           Data.Char (isAlphaNum, ord)
 import           Data.Function (on)
 import           Data.List
 import qualified Data.Map as Map
@@ -23,6 +24,7 @@ import qualified Data.Set as Set
 import           Data.Set (Set)
 
 import           Language.Haskell.TH.Lib
+import           Language.Haskell.TH.Ppr (pprint)
 import           Language.Haskell.TH.Syntax
 
 #ifndef CURRENT_PACKAGE_KEY
@@ -303,6 +305,139 @@ dataDecCons (NewtypeInstD _ _ _ con  _) = [con]
 dataDecCons _ = error "Must be a data or newtype declaration."
 #endif
 
+-- | Indicates whether Generic(1) is being derived for a plain data type (DataPlain)
+-- or a data family instance (DataFamily). DataFamily bundles the Name of the data
+-- family instance's first constructor (for Name-generation purposes) and the types
+-- used to instantiate the instance.
+data DataVariety = DataPlain | DataFamily Name [Type]
+
+showsDataVariety :: DataVariety -> ShowS
+showsDataVariety dv = (++ '_':label dv)
+  where
+    label DataPlain        = "Plain"
+    label (DataFamily n _) = "Family_" ++ sanitizeName (nameBase n)
+
+showNameQual :: Name -> String
+showNameQual = sanitizeName . showQual
+  where
+    showQual (Name _ (NameQ m))       = modString m
+    showQual (Name _ (NameG _ pkg m)) = pkgString pkg ++ ":" ++ modString m
+    showQual _                        = ""
+
+-- | Credit to Víctor López Juan for this trick
+sanitizeName :: String -> String
+sanitizeName nb = 'N':(
+    nb >>= \x -> case x of
+      c | isAlphaNum c || c == '\''-> [c]
+      '_' -> "__"
+      c   -> "_" ++ show (ord c))
+
+-- | One of the last type variables cannot be eta-reduced (see the canEtaReduce
+-- function for the criteria it would have to meet).
+etaReductionError :: Type -> a
+etaReductionError instanceType = error $
+  "Cannot eta-reduce to an instance of form \n\tinstance (...) => "
+  ++ pprint instanceType
+
+-- | Either the given data type doesn't have enough type variables, or one of
+-- the type variables to be eta-reduced cannot realize kind *.
+derivingKindError :: Name -> a
+derivingKindError tyConName = error
+  . showString "Cannot derive well-kinded instance of form ‘Generic1 "
+  . showParen True
+    ( showString (nameBase tyConName)
+    . showString " ..."
+    )
+  . showString "‘\n\tClass Generic1 expects an argument of kind * -> *"
+  $ ""
+
+outOfPlaceTyVarError :: a
+outOfPlaceTyVarError = error $
+    "Type applied to an argument involving the last parameter is not of kind * -> *"
+
+-- | Deriving Generic(1) doesn't work with ExistentialQuantification
+forallCError :: Con -> a
+forallCError con = error $
+  nameBase (constructorName con) ++ " must be a vanilla data constructor"
+
+-- | Cannot have a constructor argument of form (forall a1 ... an. <type>)
+-- when deriving Generic(1)
+rankNError :: a
+rankNError = error "Cannot have polymorphic arguments"
+
+-- | Boilerplate for top level splices.
+--
+-- The given Name must meet one of two criteria:
+--
+-- 1. It must be the name of a type constructor of a plain data type or newtype.
+-- 2. It must be the name of a data family instance or newtype instance constructor.
+--
+-- Any other value will result in an exception.
+reifyDataInfo :: Name
+              -> Q (Either String (Name, Bool, [TyVarBndr], [Con], DataVariety))
+reifyDataInfo name = do
+  info <- reify name
+  case info of
+    TyConI dec ->
+      return $ case dec of
+        DataD    ctxt _ tvbs cons _ -> Right $
+          checkDataContext name ctxt (name, False, tvbs, cons, DataPlain)
+        NewtypeD ctxt _ tvbs con  _ -> Right $
+          checkDataContext name ctxt (name, True, tvbs, [con], DataPlain)
+        TySynD{} -> Left $ ns ++ "Type synonyms are not supported."
+        _        -> Left $ ns ++ "Unsupported type: " ++ show dec
+#if MIN_VERSION_template_haskell(2,7,0)
+# if MIN_VERSION_template_haskell(2,11,0)
+    DataConI _ _ parentName   -> do
+# else
+    DataConI _ _ parentName _ -> do
+# endif
+      parentInfo <- reify parentName
+      return $ case parentInfo of
+# if MIN_VERSION_template_haskell(2,11,0)
+        FamilyI (DataFamilyD _ tvbs _) decs ->
+# else
+        FamilyI (FamilyD DataFam _ tvbs _) decs ->
+# endif
+          -- This isn't total, but the API requires that the data family instance have
+          -- at least one constructor anyways, so this will always succeed.
+          let instDec = flip find decs $ any ((name ==) . constructorName) . dataDecCons
+           in case instDec of
+                Just (DataInstD    ctxt _ instTys cons _) -> Right $
+                  checkDataContext parentName ctxt
+                    (parentName, False, tvbs, cons, DataFamily (constructorName $ head cons) instTys)
+                Just (NewtypeInstD ctxt _ instTys con  _) -> Right $
+                  checkDataContext parentName ctxt
+                    (parentName, True, tvbs, [con], DataFamily (constructorName con) instTys)
+                _ -> Left $ ns ++
+                  "Could not find data or newtype instance constructor."
+        _ -> Left $ ns ++ "Data constructor " ++ show name ++
+          " is not from a data family instance constructor."
+# if MIN_VERSION_template_haskell(2,11,0)
+    FamilyI DataFamilyD{} _ ->
+# else
+    FamilyI (FamilyD DataFam _ _ _) _ ->
+# endif
+      return . Left $
+        ns ++ "Cannot use a data family name. Use a data family instance constructor instead."
+    _ -> return . Left $ ns ++ "The name must be of a plain data type constructor, "
+                            ++ "or a data family instance constructor."
+#else
+    DataConI{} -> return . Left $ ns ++ "Cannot use a data constructor."
+        ++ "\n\t(Note: if you are trying to derive for a data family instance, use GHC >= 7.4 instead.)"
+    _          -> return . Left $ ns ++ "The name must be of a plain type constructor."
+#endif
+  where
+    ns :: String
+    ns = "Generics.Deriving.TH.reifyDataInfo: "
+
+-- | One cannot derive Generic(1) instance for anything that uses DatatypeContexts,
+-- so check to make sure the Cxt field of a datatype is null.
+checkDataContext :: Name -> Cxt -> a -> a
+checkDataContext _        [] x = x
+checkDataContext dataName _  _ = error $
+  nameBase dataName ++ " must not have a datatype context"
+
 -------------------------------------------------------------------------------
 -- Manually quoted names
 -------------------------------------------------------------------------------
@@ -571,6 +706,13 @@ trueDataName :: Name
 trueDataName = mkNameG_d "ghc-prim" "GHC.Types" "True"
 #else
 trueDataName = mkNameG_d "ghc-prim" "GHC.Bool" "True"
+#endif
+
+falseDataName :: Name
+#if __GLASGOW_HASKELL__ >= 701
+falseDataName = mkNameG_d "ghc-prim" "GHC.Types" "False"
+#else
+falseDataName = mkNameG_d "ghc-prim" "GHC.Bool" "False"
 #endif
 
 mkGHCPrim_tc :: String -> Name

--- a/src/Generics/Deriving/TH/Post711.hs
+++ b/src/Generics/Deriving/TH/Post711.hs
@@ -1,0 +1,69 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Generics.Deriving.TH.Post711
+-- Copyright   :  (c) 2008--2009 Universiteit Utrecht
+-- License     :  BSD3
+--
+-- Maintainer  :  generics@haskell.org
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Template Haskell machinery for the type-literal-based variant of GHC
+-- generics introduced in GHC 7.11.
+-----------------------------------------------------------------------------
+
+module Generics.Deriving.TH.Post711 where
+
+import Generics.Deriving.TH.Internal
+import Language.Haskell.TH.Syntax
+
+mkMetaDataType :: Name -> Bool -> Q Type
+mkMetaDataType n isNewtype =
+           promotedT metaDataDataName
+    `appT` litT (strTyLit (nameBase n))
+    `appT` litT (strTyLit m)
+    `appT` litT (strTyLit pkg)
+    `appT` promoteBool isNewtype
+  where
+    m, pkg :: String
+    m   = maybe (error "Cannot fetch module name!")  id (nameModule n)
+    pkg = maybe (error "Cannot fetch package name!") id (namePackage n)
+
+mkMetaConsType :: Name -> Bool -> Q Type
+mkMetaConsType n conIsRecord = do
+    i <- reify n
+    fi <- case i of
+               DataConI{} -> reifyFixity n
+               _ -> error $ "Not a data constructor name: " ++ show n
+    promotedT metaConsDataName
+      `appT` litT (strTyLit (nameBase n))
+      `appT` fixityIPromotedType conIsRecord fi
+      `appT` promoteBool conIsRecord
+
+promoteBool :: Bool -> Q Type
+promoteBool b = promotedT boolDataName
+  where
+    promoteBool
+      | b         = trueDataName
+      | otherwise = falseDataName
+
+fixityIPromotedType :: Bool -> Fixity -> Q Type
+fixityIPromotedType True (Fixity n a) =
+         promotedT infixIDataName
+  `appT` promoteAssociativity a
+  `appT` litT (intTyLit n)
+fixityIPromotedType False _ = promotedT prefixIDataName
+
+promoteAssociativity :: FixityDirection -> Q Type
+promoteAssociativity InfixL = promotedT leftAssociativeDataName
+promoteAssociativity InfixR = promotedT rightAssociativeDataName
+promoteAssociativity InfixN = promotedT notAssociativeDataName
+
+mkMetaSelType :: Name -> Q Type
+mkMetaSelType n = promotedT metaSelDataName `appT` litT (strTyLit (nameBase n))
+
+mkMetaNoSelType :: Q Type
+mkMetaNoSelType = promotedT metaNoSelDataName
+
+deriveMeta :: Name -> Q [Dec]
+deriveMeta _ = return []

--- a/src/Generics/Deriving/TH/Post711.hs
+++ b/src/Generics/Deriving/TH/Post711.hs
@@ -12,13 +12,24 @@
 -- generics introduced in GHC 7.11.
 -----------------------------------------------------------------------------
 
-module Generics.Deriving.TH.Post711 where
+module Generics.Deriving.TH.Post711 (
+      deriveMeta
+    , deriveData
+    , deriveConstructors
+    , deriveSelectors
+    , mkMetaDataType
+    , mkMetaConsType
+    , mkMetaSelType
+    , mkMetaNoSelType
+  ) where
 
 import Generics.Deriving.TH.Internal
+
+import Language.Haskell.TH.Lib
 import Language.Haskell.TH.Syntax
 
-mkMetaDataType :: Name -> Bool -> Q Type
-mkMetaDataType n isNewtype =
+mkMetaDataType :: DataVariety -> Name -> Bool -> Q Type
+mkMetaDataType _ n isNewtype =
            promotedT metaDataDataName
     `appT` litT (strTyLit (nameBase n))
     `appT` litT (strTyLit m)
@@ -29,8 +40,8 @@ mkMetaDataType n isNewtype =
     m   = maybe (error "Cannot fetch module name!")  id (nameModule n)
     pkg = maybe (error "Cannot fetch package name!") id (namePackage n)
 
-mkMetaConsType :: Name -> Bool -> Q Type
-mkMetaConsType n conIsRecord = do
+mkMetaConsType :: DataVariety -> Name -> Name -> Bool -> Q Type
+mkMetaConsType _ _ n conIsRecord = do
     i <- reify n
     fi <- case i of
                DataConI{} -> reifyFixity n
@@ -43,7 +54,7 @@ mkMetaConsType n conIsRecord = do
 promoteBool :: Bool -> Q Type
 promoteBool b = promotedT boolDataName
   where
-    promoteBool
+    boolDataName
       | b         = trueDataName
       | otherwise = falseDataName
 
@@ -51,7 +62,7 @@ fixityIPromotedType :: Bool -> Fixity -> Q Type
 fixityIPromotedType True (Fixity n a) =
          promotedT infixIDataName
   `appT` promoteAssociativity a
-  `appT` litT (intTyLit n)
+  `appT` litT (numTyLit (toInteger n))
 fixityIPromotedType False _ = promotedT prefixIDataName
 
 promoteAssociativity :: FixityDirection -> Q Type
@@ -59,11 +70,39 @@ promoteAssociativity InfixL = promotedT leftAssociativeDataName
 promoteAssociativity InfixR = promotedT rightAssociativeDataName
 promoteAssociativity InfixN = promotedT notAssociativeDataName
 
-mkMetaSelType :: Name -> Q Type
-mkMetaSelType n = promotedT metaSelDataName `appT` litT (strTyLit (nameBase n))
+mkMetaSelType :: DataVariety -> Name -> Name -> Name -> Q Type
+mkMetaSelType _ _ _ n = promotedT metaSelDataName `appT` litT (strTyLit (nameBase n))
 
 mkMetaNoSelType :: Q Type
 mkMetaNoSelType = promotedT metaNoSelDataName
 
+-- | Given the type and the name (as string) for the type to derive,
+-- generate the 'Data' instance, the 'Constructor' instances, and the 'Selector'
+-- instances.
+--
+-- On GHC 7.11 and up, this functionality is no longer used in GHC generics,
+-- so this function generates no declarations.
 deriveMeta :: Name -> Q [Dec]
 deriveMeta _ = return []
+
+-- | Given a datatype name, derive a datatype and instance of class 'Datatype'.
+--
+-- On GHC 7.11 and up, this functionality is no longer used in GHC generics,
+-- so this function generates no declarations.
+deriveData :: Name -> Q [Dec]
+deriveData _ = return []
+
+-- | Given a datatype name, derive datatypes and
+-- instances of class 'Constructor'.
+--
+-- On GHC 7.11 and up, this functionality is no longer used in GHC generics,
+-- so this function generates no declarations.
+deriveConstructors :: Name -> Q [Dec]
+deriveConstructors _ = return []
+
+-- | Given a datatype name, derive datatypes and instances of class 'Selector'.
+--
+-- On GHC 7.11 and up, this functionality is no longer used in GHC generics,
+-- so this function generates no declarations.
+deriveSelectors :: Name -> Q [Dec]
+deriveSelectors _ = return []

--- a/src/Generics/Deriving/TH/Pre711.hs
+++ b/src/Generics/Deriving/TH/Pre711.hs
@@ -1,0 +1,15 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Generics.Deriving.TH.Pre711
+-- Copyright   :  (c) 2008--2009 Universiteit Utrecht
+-- License     :  BSD3
+--
+-- Maintainer  :  generics@haskell.org
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Template Haskell machinery for the proxy datatype variant of GHC generics
+-- used up until GHC 7.11.
+-----------------------------------------------------------------------------
+
+module Generics.Deriving.TH.Pre711 where

--- a/src/Generics/Deriving/TH/Pre711.hs
+++ b/src/Generics/Deriving/TH/Pre711.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Generics.Deriving.TH.Pre711
@@ -12,4 +14,173 @@
 -- used up until GHC 7.11.
 -----------------------------------------------------------------------------
 
-module Generics.Deriving.TH.Pre711 where
+module Generics.Deriving.TH.Pre711 (
+      deriveMeta
+    , deriveData
+    , deriveConstructors
+    , deriveSelectors
+    , mkMetaDataType
+    , mkMetaConsType
+    , mkMetaSelType
+    , mkMetaNoSelType
+  ) where
+
+import Data.List (intercalate)
+
+import Generics.Deriving.TH.Internal
+
+import Language.Haskell.TH.Lib
+import Language.Haskell.TH.Syntax
+
+-- | Given the type and the name (as string) for the type to derive,
+-- generate the 'Data' instance, the 'Constructor' instances, and the 'Selector'
+-- instances.
+deriveMeta :: Name -> Q [Dec]
+deriveMeta n =
+  do a <- deriveData n
+     b <- deriveConstructors n
+     c <- deriveSelectors n
+     return (a ++ b ++ c)
+
+-- | Given a datatype name, derive a datatype and instance of class 'Datatype'.
+deriveData :: Name -> Q [Dec]
+deriveData = dataInstance
+
+-- | Given a datatype name, derive datatypes and
+-- instances of class 'Constructor'.
+deriveConstructors :: Name -> Q [Dec]
+deriveConstructors = constrInstance
+
+-- | Given a datatype name, derive datatypes and instances of class 'Selector'.
+deriveSelectors :: Name -> Q [Dec]
+deriveSelectors = selectInstance
+
+dataInstance :: Name -> Q [Dec]
+dataInstance n = do
+  i <- reifyDataInfo n
+  case i of
+    Left  _                    -> return []
+    Right (n', isNT, _, _, dv) -> mkInstance n' dv isNT
+  where
+    mkInstance n' dv isNT = do
+      ds <- mkDataData dv n'
+      is <- mkDataInstance dv n' isNT
+      return $ [ds,is]
+
+constrInstance :: Name -> Q [Dec]
+constrInstance n = do
+  i <- reifyDataInfo n
+  case i of
+    Left  _               -> return []
+    Right (n', _, _, cs, dv) -> mkInstance n' cs dv
+  where
+    mkInstance n' cs dv = do
+      ds <- mapM (mkConstrData dv n') cs
+      is <- mapM (mkConstrInstance dv n') cs
+      return $ ds ++ is
+
+selectInstance :: Name -> Q [Dec]
+selectInstance n = do
+  i <- reifyDataInfo n
+  case i of
+    Left  _               -> return []
+    Right (n', _, _, cs, dv) -> mkInstance n' cs dv
+  where
+    mkInstance n' cs dv = do
+      ds <- mapM (mkSelectData dv n') cs
+      is <- mapM (mkSelectInstance dv n') cs
+      return $ concat (ds ++ is)
+
+mkDataData :: DataVariety -> Name -> Q Dec
+mkDataData dv n = dataD (cxt []) (genName dv [n]) [] [] []
+
+mkConstrData :: DataVariety -> Name -> Con -> Q Dec
+mkConstrData dv dt (NormalC n _) =
+  dataD (cxt []) (genName dv [dt, n]) [] [] []
+mkConstrData dv dt r@(RecC _ _) =
+  mkConstrData dv dt (stripRecordNames r)
+mkConstrData dv dt (InfixC t1 n t2) =
+  mkConstrData dv dt (NormalC n [t1,t2])
+mkConstrData _ _ (ForallC _ _ con) = forallCError con
+
+mkSelectData :: DataVariety -> Name -> Con -> Q [Dec]
+mkSelectData dv dt (RecC n fs) = return (map one fs)
+  where one (f, _, _) = DataD [] (genName dv [dt, n, f]) [] [] []
+mkSelectData _ _ _ = return []
+
+mkDataInstance :: DataVariety -> Name -> Bool -> Q Dec
+mkDataInstance dv n isNewtype =
+  instanceD (cxt []) (appT (conT datatypeTypeName) (mkMetaDataType dv n isNewtype)) $
+    [ funD datatypeNameValName [clause [wildP] (normalB (stringE (nameBase n))) []]
+    , funD moduleNameValName   [clause [wildP] (normalB (stringE name)) []]
+    ]
+#if __GLASGOW_HASKELL__ >= 708
+ ++ if isNewtype
+       then [funD isNewtypeValName [clause [wildP] (normalB (conE trueDataName)) []]]
+       else []
+#endif
+  where
+    name = maybe (error "Cannot fetch module name!") id (nameModule n)
+
+liftFixity :: Fixity -> Q Exp
+liftFixity (Fixity n a) = conE infixDataName
+    `appE` liftAssociativity a
+    `appE` lift n
+
+liftAssociativity :: FixityDirection -> Q Exp
+liftAssociativity InfixL = conE leftAssociativeDataName
+liftAssociativity InfixR = conE rightAssociativeDataName
+liftAssociativity InfixN = conE notAssociativeDataName
+
+mkConstrInstance :: DataVariety -> Name -> Con -> Q Dec
+mkConstrInstance dv dt (NormalC n _) = mkConstrInstanceWith dv dt n False []
+mkConstrInstance dv dt (RecC    n _) = mkConstrInstanceWith dv dt n True
+      [ funD conIsRecordValName [clause [wildP] (normalB (conE trueDataName)) []]]
+mkConstrInstance dv dt (InfixC _ n _) =
+    do
+      i <- reify n
+      let fi = case i of
+                 DataConI _ _ _ f -> f
+                 _ -> error $ "Not a data constructor name: " ++ show n
+      instanceD (cxt []) (appT (conT constructorTypeName) (mkMetaConsType dv dt n False))
+        [funD conNameValName   [clause [wildP] (normalB (stringE (nameBase n))) []],
+         funD conFixityValName [clause [wildP] (normalB (liftFixity fi)) []]]
+mkConstrInstance _ _ (ForallC _ _ con) = forallCError con
+
+mkConstrInstanceWith :: DataVariety -> Name -> Name -> Bool -> [Q Dec] -> Q Dec
+mkConstrInstanceWith dv dt n isRecord extra =
+  instanceD (cxt []) (appT (conT constructorTypeName) (mkMetaConsType dv dt n isRecord))
+    (funD conNameValName [clause [wildP] (normalB (stringE (nameBase n))) []] : extra)
+
+mkSelectInstance :: DataVariety -> Name -> Con -> Q [Dec]
+mkSelectInstance dv dt (RecC n fs) = mapM one fs where
+  one :: VarStrictType -> Q Dec
+  one (f, _, _) =
+    instanceD (cxt []) (appT (conT selectorTypeName) (mkMetaSelType dv dt n f))
+      [funD selNameValName [clause [wildP]
+        (normalB (litE (stringL (nameBase f)))) []]]
+mkSelectInstance _ _ _ = return []
+
+genName :: DataVariety -> [Name] -> Name
+genName dv ns = mkName
+              . showsDataVariety dv
+              . intercalate "_"
+              . consQualName
+              $ map (sanitizeName . nameBase) ns
+  where
+    consQualName :: [String] -> [String]
+    consQualName = case ns of
+        []  -> id
+        n:_ -> (showNameQual n :)
+
+mkMetaDataType :: DataVariety -> Name -> Bool -> Q Type
+mkMetaDataType dv n _ = conT $ genName dv [n]
+
+mkMetaConsType :: DataVariety -> Name -> Name -> Bool -> Q Type
+mkMetaConsType dv dt n _ = conT $ genName dv [dt, n]
+
+mkMetaSelType :: DataVariety -> Name -> Name -> Name -> Q Type
+mkMetaSelType dv dt n f = conT $ genName dv [dt, n, f]
+
+mkMetaNoSelType :: Q Type
+mkMetaNoSelType = conT noSelectorTypeName


### PR DESCRIPTION
Now that http://git.haskell.org/ghc.git/commit/700c42b5e0ffd27884e6bdfa9a940e55449cff6f has been committed, we need to update the Tempate Haskell codegen to account for this. This turns out to be easy, since we now generate far less code than before!