### PR TITLE
Fixes for 8.0.1-rc1

### DIFF
--- a/src/Generics/Deriving/TH/Internal.hs
+++ b/src/Generics/Deriving/TH/Internal.hs
@@ -301,8 +301,8 @@ constructorName (RecC    name      _  ) = name
 constructorName (InfixC  _    name _  ) = name
 constructorName (ForallC _    _    con) = constructorName con
 #if MIN_VERSION_template_haskell(2,11,0)
-constructorName (GadtC    _ _ name _) = name
-constructorName (RecGadtC _ _ name _) = name
+constructorName (GadtC    names _ _) = head names
+constructorName (RecGadtC names _ _) = head names
 #endif
 
 #if MIN_VERSION_template_haskell(2,7,0)

--- a/src/Generics/Deriving/TH/Post711.hs
+++ b/src/Generics/Deriving/TH/Post711.hs
@@ -61,11 +61,12 @@ promoteBool b = promotedT boolDataName
       | b         = trueDataName
       | otherwise = falseDataName
 
-fixityIPromotedType :: Bool -> Fixity -> Q Type
-fixityIPromotedType True (Fixity n a) =
+fixityIPromotedType :: Bool -> Maybe Fixity -> Q Type
+fixityIPromotedType True (Just (Fixity n a)) =
          promotedT infixIDataName
   `appT` promoteAssociativity a
   `appT` litT (numTyLit (toInteger n))
+fixityIPromotedType True  _ = promotedT prefixIDataName
 fixityIPromotedType False _ = promotedT prefixIDataName
 
 promoteAssociativity :: FixityDirection -> Q Type


### PR DESCRIPTION
This patch addresses two changes in `template-haskell-2.11.0.0`:

1. It looks like the layout of the `GadtC` constructor has changed since support was originally added for `template-haskell-2.11.0.0`. The old constructor had four fields, one of which was a single name, though now there is only a list of names present. The problem seems only present with the definition of `constructorName` which isn't used outside of the `Internal` module.
2. The `Fixity` field present on `DataConI` turned into `Maybe Fixity`

I addressed 1 by always taking the head of the name list present on `GadtC`. As this function is only ever used in a context where the data type is assumed to be plain or a newtype, this seemed like an OK compromise. One caveat is that the `gadtError` function from `Generics.Deriving.TH.Internal` will only ever list the constructor from the head of that list, but maybe that's alright.

2 is addressed by just processing the promoted type as though the fixity information was not present. This might not be the right behavior, so it would be nice to have someone else check that :)