### PR TITLE
Introduce examples using DerivingVia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Functions in `Generics.Deriving.TH` now balance groups of `(:*:)` and `(:+:)`
   as much as possible (`deriving Generic` was already performing this
   optimization, and now `generic-deriving` does too).
+* Add a `Generics.Deriving.Default` module demonstrating and explaining
+  how and why to use `DerivingVia`. There is also a test suite with
+  further examples.
 
 # 1.12.2 [2018.06.28]
 * Backport the `Generic(1)` instances for `Data.Ord.Down`, introduced in

--- a/generic-deriving.cabal
+++ b/generic-deriving.cabal
@@ -91,6 +91,8 @@ test-suite spec
   other-modules:        EmptyCaseSpec
                         ExampleSpec
                         TypeInTypeSpec
+  if impl(ghc >= 8.6.1)
+    other-modules:      DefaultSpec
   build-depends:        base             >= 4.3  && < 5
                       , generic-deriving
                       , hspec            >= 2    && < 3

--- a/generic-deriving.cabal
+++ b/generic-deriving.cabal
@@ -88,11 +88,10 @@ library
 test-suite spec
   type:                 exitcode-stdio-1.0
   main-is:              Spec.hs
-  other-modules:        EmptyCaseSpec
+  other-modules:        DefaultSpec
+                        EmptyCaseSpec
                         ExampleSpec
                         TypeInTypeSpec
-  if impl(ghc >= 8.6.1)
-    other-modules:      DefaultSpec
   build-depends:        base             >= 4.3  && < 5
                       , generic-deriving
                       , hspec            >= 2    && < 3

--- a/generic-deriving.cabal
+++ b/generic-deriving.cabal
@@ -54,6 +54,7 @@ library
                         Generics.Deriving.Instances
                         Generics.Deriving.Copoint
                         Generics.Deriving.ConNames
+                        Generics.Deriving.Default
                         Generics.Deriving.Enum
                         Generics.Deriving.Eq
                         Generics.Deriving.Foldable

--- a/src/Generics/Deriving.hs
+++ b/src/Generics/Deriving.hs
@@ -4,6 +4,7 @@ module Generics.Deriving (
     module Generics.Deriving.Base,
     module Generics.Deriving.Copoint,
     module Generics.Deriving.ConNames,
+    module Generics.Deriving.Default,
     module Generics.Deriving.Enum,
     module Generics.Deriving.Eq,
     module Generics.Deriving.Functor,
@@ -15,6 +16,7 @@ module Generics.Deriving (
 import Generics.Deriving.Base
 import Generics.Deriving.Copoint
 import Generics.Deriving.ConNames
+import Generics.Deriving.Default
 import Generics.Deriving.Enum
 import Generics.Deriving.Eq
 import Generics.Deriving.Functor

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -1,5 +1,50 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 701
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE Safe #-}
+#endif
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Generics.Deriving.Default
   ( Default(..)
   ) where
 
+import Generics.Deriving.Base
+import Generics.Deriving.Enum
+import Generics.Deriving.Eq
+import Generics.Deriving.Show
+
 newtype Default a = Default a
+
+--------------------------------------------------------------------------------
+-- Eq
+--------------------------------------------------------------------------------
+
+instance (Generic a, GEq' (Rep a)) => Eq (Default a) where
+  Default x == Default y = x `geqdefault` y
+
+instance (Generic a, GEq' (Rep a)) => GEq (Default a) where
+  Default x `geq` Default y = x `geqdefault` y
+
+--------------------------------------------------------------------------------
+-- Enum
+--------------------------------------------------------------------------------
+
+instance (Generic a, GEq a, Enum' (Rep a)) => Enum (Default a) where
+  toEnum = Default . toEnumDefault
+  fromEnum (Default x) = fromEnumDefault x
+
+instance (Generic a, GEq a, Enum' (Rep a)) => GEnum (Default a) where
+  genum = Default . to <$> enum'
+
+--------------------------------------------------------------------------------
+-- Show
+--------------------------------------------------------------------------------
+
+instance (Generic a, GShow' (Rep a)) => Show (Default a) where
+  showsPrec n (Default x) = gshowsPrecdefault n x
+
+instance (Generic a, GShow' (Rep a)) => GShow (Default a) where
+  gshowsPrec n (Default x) = gshowsPrecdefault n x
+

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -8,22 +8,45 @@
 -- Portability : non-portable
 --
 -- GHC 8.6 introduced the 'DerivingVia' language extension, which means
--- an instance of a typeclass for a type can be derived from an instance
--- for an isomorphic type.
+-- a typeclass instance can be derived from an existing instance for an
+-- isomorphic type. Any newtype is isomorphic to the underlying type. By
+-- implementing a typeclass once for the newtype, it is possible to derive
+-- any typeclass for any type with a 'Generic' instance.
 --
--- There are a number of default instantiations for the classes to be
--- derived via generics in this package. This module exports the 'Default'
--- newtype, which indicates that a type should use those default instances
--- for its typeclass instances.
+-- For a number of classes, there are sensible default instantiations. In
+-- older GHCs, these can be supplied in the class definition, using the
+-- 'DefaultSignatures' extension. However, only one default can be
+-- provided! With 'DerivingVia' it is now possible to choose from many
+-- default instantiations.
 --
--- Use as follows:
+-- This package contains a number of such classes. This module demonstrates
+-- how one might create a newtype called 'Default' for which such instances
+-- are defined.
+--
+-- Then one might use 'DerivingVia' as follows. The implementations of the
+-- data types are elided here (they are irrelevant). Either the deriving
+-- clause with the data type definition or the standalone clause will work.
+--
+-- 1.  For data types of kind '*', use 'Default'.
 --
 -- @
 -- data MyType = …
 --  deriving (Generic)
---  deriving (Eq) via (Default MyType)
+--  deriving (GEq) via (Default MyType)
 --
--- deriving via (Default MyType) instance Show MyType
+-- deriving via (Default MyType) instance GShow MyType
+-- @
+--
+-- TODO Confirm classes of kind '* -> Constraint' vs kind 'Constraint'
+--
+-- 2.  For data types of kind '* -> *', use 'Default1'.
+--
+-- @
+-- data MyType1 a = …
+--  deriving (Generic)
+--  deriving (GFunctor) via (Default1 MyType1)
+--
+-- deriving via (Default1 MyType1) instance GFoldable MyType1
 -- @
 
 {-# LANGUAGE CPP #-}
@@ -51,8 +74,12 @@ import Generics.Deriving.Show
 import Generics.Deriving.Traversable
 import Generics.Deriving.Uniplate
 
+-- | This newtype wrapper can be used to derive default instances for data
+-- types of kind '*'.
 newtype Default a = Default { unDefault :: a }
 
+-- | This newtype wrapper can be used to derive default instances for data
+-- types of kind '* -> *'.
 newtype Default1 f a = Default1 { unDefault1 :: f a }
 
 --------------------------------------------------------------------------------

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -39,6 +39,7 @@
 
 module Generics.Deriving.Default
   ( Default(..)
+  , Default1(..)
   ) where
 
 import Data.Foldable
@@ -101,7 +102,7 @@ instance (Generic a, GShow' (Rep a)) => Show (Default a) where
 #if __GLASGOW_HASKELL__ >= 706
   showsPrec :: Int -> Default a -> ShowS
 #endif
-  showsPrec n (Default x) = gshowsPrecdefault n x
+  showsPrec = gshowsPrec
 
 instance (Generic a, GShow' (Rep a)) => GShow (Default a) where
 #if __GLASGOW_HASKELL__ >= 706
@@ -117,7 +118,7 @@ instance (Generic a, GSemigroup' (Rep a)) => Semigroup (Default a) where
 #if __GLASGOW_HASKELL__ >= 706
   (<>) :: Default a -> Default a -> Default a
 #endif
-  Default x <> Default y = Default $ x `gsappenddefault` y
+  (<>) = gsappend
 
 instance (Generic a, GSemigroup' (Rep a)) => GSemigroup (Default a) where
 #if __GLASGOW_HASKELL__ >= 706
@@ -138,8 +139,8 @@ instance (Generic a, GMonoid' (Rep a)) => Monoid (Default a) where
   mempty :: Default a
   mappend :: Default a -> Default a -> Default a
 #endif
-  mempty = Default gmemptydefault
-  Default x `mappend` Default y = Default $ x `gmappenddefault` y
+  mempty = gmempty
+  mappend = gmappend
 
 instance (Generic a, GMonoid' (Rep a)) => GMonoid (Default a) where
 #if __GLASGOW_HASKELL__ >= 706

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -41,6 +41,7 @@ module Generics.Deriving.Default
 import Generics.Deriving.Base
 import Generics.Deriving.Enum
 import Generics.Deriving.Eq
+import Generics.Deriving.Monoid
 import Generics.Deriving.Semigroup
 import Generics.Deriving.Show
 
@@ -86,4 +87,20 @@ instance (Generic a, GSemigroup' (Rep a)) => Semigroup (Default a) where
 
 instance (Generic a, GSemigroup' (Rep a)) => GSemigroup (Default a) where
   Default x `gsappend` Default y = Default $ x `gsappenddefault` y
+
+--------------------------------------------------------------------------------
+-- Monoid
+--------------------------------------------------------------------------------
+
+#if (MIN_VERSION_base(4,11,0))
+instance (Generic a, GMonoid' (Rep a), Semigroup a, GSemigroup' (Rep a)) => Monoid (Default a) where
+#else
+instance (Generic a, GMonoid' (Rep a)) => Monoid (Default a) where
+#endif
+  mempty = Default gmemptydefault
+  Default x `mappend` Default y = Default $ x `gmappenddefault` y
+
+instance (Generic a, GMonoid' (Rep a)) => GMonoid (Default a) where
+  gmempty = Default gmemptydefault
+  Default x `gmappend` Default y = Default $ x `gmappenddefault` y
 

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -91,14 +91,6 @@ newtype Default1 f a = Default1 { unDefault1 :: f a }
 -- Eq
 --------------------------------------------------------------------------------
 
--- |
---
--- @
--- instance (Generic a, GEq' (Rep a)) => Eq (Default a) where
---   (==) :: Default a -> Default a -> Bool
---   Default x == Default y = x `geqdefault` y
--- @
---
 instance (Generic a, GEq' (Rep a)) => GEq (Default a) where
   -- geq :: Default a -> Default a -> Bool
   Default x `geq` Default y = x `geqdefault` y
@@ -107,17 +99,9 @@ instance (Generic a, GEq' (Rep a)) => GEq (Default a) where
 -- Enum
 --------------------------------------------------------------------------------
 
--- |
---
--- @
--- instance (Generic a, GEq a, Enum' (Rep a)) => Enum (Default a) where
---   toEnum :: Int -> Default a
---   toEnum = Default . toEnumDefault
---
---   fromEnum :: Default a -> Int
---   fromEnum (Default x) = fromEnumDefault x
--- @
---
+-- | The 'Enum' class in 'base' is slightly different; it comprises 'toEnum' and
+-- 'fromEnum'. 'Generics.Deriving.Enum' provides functions 'toEnumDefault'
+-- and 'fromEnumDefault'.
 instance (Generic a, GEq a, Enum' (Rep a)) => GEnum (Default a) where
   -- genum :: [Default a]
   genum = Default . to <$> enum'
@@ -126,14 +110,15 @@ instance (Generic a, GEq a, Enum' (Rep a)) => GEnum (Default a) where
 -- Show
 --------------------------------------------------------------------------------
 
--- |
+-- | For example, with this type:
 --
 -- @
--- instance (Generic a, GShow' (Rep a)) => Show (Default a) where
---   showsPrec :: Int -> Default a -> ShowS
---   showsPrec = gshowsPrec
+-- newtype TestShow = TestShow Bool
+--   deriving (GShow) via (Default Bool)
 -- @
 --
+-- `gshow` for `TestShow` would produce the same string as `gshow` for
+-- `Bool`.
 instance (Generic a, GShow' (Rep a)) => GShow (Default a) where
   -- gshowsPrec :: Int -> Default a -> ShowS
   gshowsPrec n (Default x) = gshowsPrecdefault n x
@@ -142,12 +127,17 @@ instance (Generic a, GShow' (Rep a)) => GShow (Default a) where
 -- Semigroup
 --------------------------------------------------------------------------------
 
--- |
+-- | Semigroups often have many sensible implementations of `gsappend`, and
+-- therefore no sensible default. Indeed, there is no 'GSemigroup''
+-- instance for representations of sum types.
+--
+-- In other cases, one may wish to use the existing wrapper newtypes in
+-- 'base', such as the following (using 'Data.Semigroup.First'):
 --
 -- @
--- instance (Generic a, GSemigroup' (Rep a)) => Semigroup (Default a) where
---   (<>) :: Default a -> Default a -> Default a
---   (<>) = gsappend
+-- newtype FirstSemigroup = FirstSemigroup Bool
+--   deriving stock (Eq, Show)
+--   deriving (GSemigroup) via (First Bool)
 -- @
 --
 instance (Generic a, GSemigroup' (Rep a)) => GSemigroup (Default a) where
@@ -158,22 +148,6 @@ instance (Generic a, GSemigroup' (Rep a)) => GSemigroup (Default a) where
 -- Monoid
 --------------------------------------------------------------------------------
 
--- |
---
--- @
--- #if (MIN_VERSION_base(4,11,0))
--- instance (Generic a, GMonoid' (Rep a), Semigroup a, GSemigroup' (Rep a)) => Monoid (Default a) where
--- #else
--- instance (Generic a, GMonoid' (Rep a)) => Monoid (Default a) where
--- #endif
---
---   mempty :: Default a
---   mempty = gmempty
---
---   mappend :: Default a -> Default a -> Default a
---   mappend = gmappend
--- @
---
 instance (Generic a, GMonoid' (Rep a)) => GMonoid (Default a) where
   -- gmempty :: Default a
   gmempty = Default gmemptydefault
@@ -205,13 +179,6 @@ instance (Generic a, Uniplate' (Rep a) a, Context' (Rep a) a) => Uniplate (Defau
 -- Functor
 --------------------------------------------------------------------------------
 
--- |
---
--- @
--- instance (Generic1 f, GFunctor' (Rep1 f)) => Functor (Default1 f) where
---   fmap = gmap
--- @
---
 instance (Generic1 f, GFunctor' (Rep1 f)) => GFunctor (Default1 f) where
   -- gmap :: (a -> b) -> (Default1 f) a -> (Default1 f) b
   gmap f (Default1 fx) = Default1 $ gmapdefault f fx
@@ -228,30 +195,6 @@ instance (Generic1 f, GCopoint' (Rep1 f)) => GCopoint (Default1 f) where
 -- Foldable
 --------------------------------------------------
 
--- |
---
--- @
--- instance (Generic1 t, GFoldable' (Rep1 t)) => Foldable (Default1 t) where
---
---   foldMap :: (Monoid m) => (a -> m) -> Default1 t a -> m
---   fold    ::  Monoid m              => Default1 t m -> m
---   foldr   :: (a -> b -> b)    -> b  -> Default1 t a -> b
---   foldr'  :: (a -> b -> b)    -> b  -> Default1 t a -> b
---   foldl   :: (a -> b -> a)    -> a  -> Default1 t b -> a
---   foldl'  :: (a -> b -> a)    -> a  -> Default1 t b -> a
---   foldr1  :: (a -> a -> a)          -> Default1 t a -> a
---   foldl1  :: (a -> a -> a)          -> Default1 t a -> a
---
---   foldMap = gfoldMap
---   fold    = gfold
---   foldr   = gfoldr
---   foldr'  = gfoldr'
---   foldl   = gfoldl
---   foldl'  = gfoldl'
---   foldr1  = gfoldr1
---   foldl1  = gfoldl1
--- @
---
 instance (Generic1 t, GFoldable' (Rep1 t)) => GFoldable (Default1 t) where
   -- gfoldMap :: Monoid m => (a -> m) -> Default1 t a -> m
   gfoldMap f (Default1 tx) = gfoldMapdefault f tx
@@ -260,22 +203,6 @@ instance (Generic1 t, GFoldable' (Rep1 t)) => GFoldable (Default1 t) where
 -- Traversable
 --------------------------------------------------
 
--- |
---
--- @
--- instance (Generic1 t, GFunctor' (Rep1 t), GFoldable' (Rep1 t), GTraversable' (Rep1 t)) => Traversable (Default1 t) where
---
---   traverse  :: Applicative f => (a -> f b) -> Default1 t    a  -> f (Default1 t b)
---   sequenceA :: Applicative f =>               Default1 t (f a) -> f (Default1 t a)
---   mapM      ::       Monad m => (a -> m b) -> Default1 t    a  -> m (Default1 t b)
---   sequence  ::       Monad m =>               Default1 t (m a) -> m (Default1 t a)
---
---   sequenceA = gsequenceA
---   mapM      = gmapM
---   sequence  = gsequence
---   traverse  = gtraverse
--- @
---
 instance (Generic1 t, GFunctor' (Rep1 t), GFoldable' (Rep1 t), GTraversable' (Rep1 t)) => GTraversable (Default1 t) where
   -- gtraverse :: Applicative f => (a -> f b) -> Default1 t a -> f (Default1 t b)
   gtraverse f (Default1 fx) = Default1 <$> gtraversedefault f fx

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -52,6 +52,7 @@ import Generics.Deriving.Functor
 import Generics.Deriving.Monoid
 import Generics.Deriving.Semigroup
 import Generics.Deriving.Show
+import Generics.Deriving.Traversable
 import Generics.Deriving.Uniplate
 
 newtype Default a = Default { unDefault :: a }
@@ -222,3 +223,25 @@ instance (Generic1 t, GFoldable' (Rep1 t)) => GFoldable (Default1 t) where
   gfoldMap :: Monoid m => (a -> m) -> Default1 t a -> m
 #endif
   gfoldMap f (Default1 tx) = gfoldMapdefault f tx
+
+--------------------------------------------------
+-- Traversable
+--------------------------------------------------
+
+instance (Generic1 t, GFunctor' (Rep1 t), GFoldable' (Rep1 t), GTraversable' (Rep1 t)) => Traversable (Default1 t) where
+#if __GLASGOW_HASKELL__ >= 706
+  traverse  :: Applicative f => (a -> f b) -> Default1 t    a  -> f (Default1 t b)
+  sequenceA :: Applicative f =>               Default1 t (f a) -> f (Default1 t a)
+  mapM      ::       Monad m => (a -> m b) -> Default1 t    a  -> m (Default1 t b)
+  sequence  ::       Monad m =>               Default1 t (m a) -> m (Default1 t a)
+#endif
+  sequenceA = gsequenceA
+  mapM      = gmapM
+  sequence  = gsequence
+  traverse  = gtraverse
+
+instance (Generic1 t, GFunctor' (Rep1 t), GFoldable' (Rep1 t), GTraversable' (Rep1 t)) => GTraversable (Default1 t) where
+#if __GLASGOW_HASKELL__ >= 706
+  gtraverse :: Applicative f => (a -> f b) -> Default1 t a -> f (Default1 t b)
+#endif
+  gtraverse f (Default1 fx) = Default1 <$> gtraversedefault f fx

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -31,9 +31,6 @@
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE Safe #-}
 #endif
-#if __GLASGOW_HASKELL__ >= 706
-{-# LANGUAGE InstanceSigs #-}
-#endif
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -65,15 +62,11 @@ newtype Default1 f a = Default1 { unDefault1 :: f a }
 --------------------------------------------------------------------------------
 
 instance (Generic a, GEq' (Rep a)) => Eq (Default a) where
-#if __GLASGOW_HASKELL__ >= 706
-  (==) :: Default a -> Default a -> Bool
-#endif
+  -- (==) :: Default a -> Default a -> Bool
   Default x == Default y = x `geqdefault` y
 
 instance (Generic a, GEq' (Rep a)) => GEq (Default a) where
-#if __GLASGOW_HASKELL__ >= 706
-  geq :: Default a -> Default a -> Bool
-#endif
+  -- geq :: Default a -> Default a -> Bool
   Default x `geq` Default y = x `geqdefault` y
 
 --------------------------------------------------------------------------------
@@ -81,17 +74,14 @@ instance (Generic a, GEq' (Rep a)) => GEq (Default a) where
 --------------------------------------------------------------------------------
 
 instance (Generic a, GEq a, Enum' (Rep a)) => Enum (Default a) where
-#if __GLASGOW_HASKELL__ >= 706
-  toEnum :: Int -> Default a
-  fromEnum :: Default a -> Int
-#endif
+  -- toEnum :: Int -> Default a
   toEnum = Default . toEnumDefault
+
+  -- fromEnum :: Default a -> Int
   fromEnum (Default x) = fromEnumDefault x
 
 instance (Generic a, GEq a, Enum' (Rep a)) => GEnum (Default a) where
-#if __GLASGOW_HASKELL__ >= 706
-  genum :: [Default a]
-#endif
+  -- genum :: [Default a]
   genum = Default . to <$> enum'
 
 --------------------------------------------------------------------------------
@@ -99,15 +89,11 @@ instance (Generic a, GEq a, Enum' (Rep a)) => GEnum (Default a) where
 --------------------------------------------------------------------------------
 
 instance (Generic a, GShow' (Rep a)) => Show (Default a) where
-#if __GLASGOW_HASKELL__ >= 706
-  showsPrec :: Int -> Default a -> ShowS
-#endif
+  -- showsPrec :: Int -> Default a -> ShowS
   showsPrec = gshowsPrec
 
 instance (Generic a, GShow' (Rep a)) => GShow (Default a) where
-#if __GLASGOW_HASKELL__ >= 706
-  gshowsPrec :: Int -> Default a -> ShowS
-#endif
+  -- gshowsPrec :: Int -> Default a -> ShowS
   gshowsPrec n (Default x) = gshowsPrecdefault n x
 
 --------------------------------------------------------------------------------
@@ -115,15 +101,11 @@ instance (Generic a, GShow' (Rep a)) => GShow (Default a) where
 --------------------------------------------------------------------------------
 
 instance (Generic a, GSemigroup' (Rep a)) => Semigroup (Default a) where
-#if __GLASGOW_HASKELL__ >= 706
-  (<>) :: Default a -> Default a -> Default a
-#endif
+  -- (<>) :: Default a -> Default a -> Default a
   (<>) = gsappend
 
 instance (Generic a, GSemigroup' (Rep a)) => GSemigroup (Default a) where
-#if __GLASGOW_HASKELL__ >= 706
-  gsappend :: Default a -> Default a -> Default a
-#endif
+  -- gsappend :: Default a -> Default a -> Default a
   Default x `gsappend` Default y = Default $ x `gsappenddefault` y
 
 --------------------------------------------------------------------------------
@@ -135,19 +117,18 @@ instance (Generic a, GMonoid' (Rep a), Semigroup a, GSemigroup' (Rep a)) => Mono
 #else
 instance (Generic a, GMonoid' (Rep a)) => Monoid (Default a) where
 #endif
-#if __GLASGOW_HASKELL__ >= 706
-  mempty :: Default a
-  mappend :: Default a -> Default a -> Default a
-#endif
+
+  -- mempty :: Default a
   mempty = gmempty
+
+  -- mappend :: Default a -> Default a -> Default a
   mappend = gmappend
 
 instance (Generic a, GMonoid' (Rep a)) => GMonoid (Default a) where
-#if __GLASGOW_HASKELL__ >= 706
-  gmempty :: Default a
-  gmappend :: Default a -> Default a -> Default a
-#endif
+  -- gmempty :: Default a
   gmempty = Default gmemptydefault
+
+  -- gmappend :: Default a -> Default a -> Default a
   Default x `gmappend` Default y = Default $ x `gmappenddefault` y
 
 --------------------------------------------------------------------------------
@@ -156,14 +137,12 @@ instance (Generic a, GMonoid' (Rep a)) => GMonoid (Default a) where
 
 instance (Generic a, Uniplate' (Rep a) a, Context' (Rep a) a) => Uniplate (Default a) where
 
-#if __GLASGOW_HASKELL__ >= 706
-  children   ::                                             Default a  ->   [Default a]
-  context    ::                             Default a   -> [Default a] ->    Default a
-  descend    ::            (Default a ->    Default a)  ->  Default a  ->    Default a
-  descendM   :: Monad m => (Default a -> m (Default a)) ->  Default a  -> m (Default a)
-  transform  ::            (Default a ->    Default a)  ->  Default a  ->    Default a
-  transformM :: Monad m => (Default a -> m (Default a)) ->  Default a  -> m (Default a)
-#endif
+  -- children   ::                                             Default a  ->   [Default a]
+  -- context    ::                             Default a   -> [Default a] ->    Default a
+  -- descend    ::            (Default a ->    Default a)  ->  Default a  ->    Default a
+  -- descendM   :: Monad m => (Default a -> m (Default a)) ->  Default a  -> m (Default a)
+  -- transform  ::            (Default a ->    Default a)  ->  Default a  ->    Default a
+  -- transformM :: Monad m => (Default a -> m (Default a)) ->  Default a  -> m (Default a)
 
   children     (Default x)    = Default <$> childrendefault    x
   context      (Default x) ys = Default  $  contextdefault     x   (unDefault <$> ys)
@@ -180,9 +159,7 @@ instance (Generic1 f, GFunctor' (Rep1 f)) => Functor (Default1 f) where
   fmap = gmap
 
 instance (Generic1 f, GFunctor' (Rep1 f)) => GFunctor (Default1 f) where
-#if __GLASGOW_HASKELL__ >= 706
-  gmap :: (a -> b) -> (Default1 f) a -> (Default1 f) b
-#endif
+  -- gmap :: (a -> b) -> (Default1 f) a -> (Default1 f) b
   gmap f (Default1 fx) = Default1 $ gmapdefault f fx
 
 --------------------------------------------------
@@ -190,9 +167,7 @@ instance (Generic1 f, GFunctor' (Rep1 f)) => GFunctor (Default1 f) where
 --------------------------------------------------
 
 instance (Generic1 f, GCopoint' (Rep1 f)) => GCopoint (Default1 f) where
-#if __GLASGOW_HASKELL__ >= 706
-  gcopoint :: Default1 f a -> a
-#endif
+  -- gcopoint :: Default1 f a -> a
   gcopoint = gcopointdefault . unDefault1
 
 --------------------------------------------------
@@ -200,16 +175,16 @@ instance (Generic1 f, GCopoint' (Rep1 f)) => GCopoint (Default1 f) where
 --------------------------------------------------
 
 instance (Generic1 t, GFoldable' (Rep1 t)) => Foldable (Default1 t) where
-#if __GLASGOW_HASKELL__ >= 706
-  foldMap :: (Monoid m) => (a -> m) -> Default1 t a -> m
-  fold    ::  Monoid m              => Default1 t m -> m
-  foldr   :: (a -> b -> b)    -> b  -> Default1 t a -> b
-  foldr'  :: (a -> b -> b)    -> b  -> Default1 t a -> b
-  foldl   :: (a -> b -> a)    -> a  -> Default1 t b -> a
-  foldl'  :: (a -> b -> a)    -> a  -> Default1 t b -> a
-  foldr1  :: (a -> a -> a)          -> Default1 t a -> a
-  foldl1  :: (a -> a -> a)          -> Default1 t a -> a
-#endif
+
+  -- foldMap :: (Monoid m) => (a -> m) -> Default1 t a -> m
+  -- fold    ::  Monoid m              => Default1 t m -> m
+  -- foldr   :: (a -> b -> b)    -> b  -> Default1 t a -> b
+  -- foldr'  :: (a -> b -> b)    -> b  -> Default1 t a -> b
+  -- foldl   :: (a -> b -> a)    -> a  -> Default1 t b -> a
+  -- foldl'  :: (a -> b -> a)    -> a  -> Default1 t b -> a
+  -- foldr1  :: (a -> a -> a)          -> Default1 t a -> a
+  -- foldl1  :: (a -> a -> a)          -> Default1 t a -> a
+
   foldMap = gfoldMap
   fold    = gfold
   foldr   = gfoldr
@@ -220,9 +195,7 @@ instance (Generic1 t, GFoldable' (Rep1 t)) => Foldable (Default1 t) where
   foldl1  = gfoldl1
 
 instance (Generic1 t, GFoldable' (Rep1 t)) => GFoldable (Default1 t) where
-#if __GLASGOW_HASKELL__ >= 706
-  gfoldMap :: Monoid m => (a -> m) -> Default1 t a -> m
-#endif
+  -- gfoldMap :: Monoid m => (a -> m) -> Default1 t a -> m
   gfoldMap f (Default1 tx) = gfoldMapdefault f tx
 
 --------------------------------------------------
@@ -230,19 +203,17 @@ instance (Generic1 t, GFoldable' (Rep1 t)) => GFoldable (Default1 t) where
 --------------------------------------------------
 
 instance (Generic1 t, GFunctor' (Rep1 t), GFoldable' (Rep1 t), GTraversable' (Rep1 t)) => Traversable (Default1 t) where
-#if __GLASGOW_HASKELL__ >= 706
-  traverse  :: Applicative f => (a -> f b) -> Default1 t    a  -> f (Default1 t b)
-  sequenceA :: Applicative f =>               Default1 t (f a) -> f (Default1 t a)
-  mapM      ::       Monad m => (a -> m b) -> Default1 t    a  -> m (Default1 t b)
-  sequence  ::       Monad m =>               Default1 t (m a) -> m (Default1 t a)
-#endif
+
+  -- traverse  :: Applicative f => (a -> f b) -> Default1 t    a  -> f (Default1 t b)
+  -- sequenceA :: Applicative f =>               Default1 t (f a) -> f (Default1 t a)
+  -- mapM      ::       Monad m => (a -> m b) -> Default1 t    a  -> m (Default1 t b)
+  -- sequence  ::       Monad m =>               Default1 t (m a) -> m (Default1 t a)
+
   sequenceA = gsequenceA
   mapM      = gmapM
   sequence  = gsequence
   traverse  = gtraverse
 
 instance (Generic1 t, GFunctor' (Rep1 t), GFoldable' (Rep1 t), GTraversable' (Rep1 t)) => GTraversable (Default1 t) where
-#if __GLASGOW_HASKELL__ >= 706
-  gtraverse :: Applicative f => (a -> f b) -> Default1 t a -> f (Default1 t b)
-#endif
+  -- gtraverse :: Applicative f => (a -> f b) -> Default1 t a -> f (Default1 t b)
   gtraverse f (Default1 fx) = Default1 <$> gtraversedefault f fx

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -42,6 +42,7 @@ module Generics.Deriving.Default
   ) where
 
 import Generics.Deriving.Base
+import Generics.Deriving.Copoint
 import Generics.Deriving.Enum
 import Generics.Deriving.Eq
 import Generics.Deriving.Functor
@@ -178,3 +179,14 @@ instance (Generic1 f, GFunctor' (Rep1 f)) => GFunctor (Default1 f) where
   gmap :: (a -> b) -> (Default1 f) a -> (Default1 f) b
 #endif
   gmap f (Default1 fx) = Default1 $ gmapdefault f fx
+
+--------------------------------------------------
+-- Copoint
+--------------------------------------------------
+
+instance (Generic1 f, GCopoint' (Rep1 f)) => GCopoint (Default1 f) where
+#if __GLASGOW_HASKELL__ >= 706
+  gcopoint :: Default1 f a -> a
+#endif
+  gcopoint = gcopointdefault . unDefault1
+

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -56,9 +56,15 @@ newtype Default a = Default { unDefault :: a }
 --------------------------------------------------------------------------------
 
 instance (Generic a, GEq' (Rep a)) => Eq (Default a) where
+#if __GLASGOW_HASKELL__ >= 706
+  (==) :: Default a -> Default a -> Bool
+#endif
   Default x == Default y = x `geqdefault` y
 
 instance (Generic a, GEq' (Rep a)) => GEq (Default a) where
+#if __GLASGOW_HASKELL__ >= 706
+  geq :: Default a -> Default a -> Bool
+#endif
   Default x `geq` Default y = x `geqdefault` y
 
 --------------------------------------------------------------------------------
@@ -66,10 +72,17 @@ instance (Generic a, GEq' (Rep a)) => GEq (Default a) where
 --------------------------------------------------------------------------------
 
 instance (Generic a, GEq a, Enum' (Rep a)) => Enum (Default a) where
+#if __GLASGOW_HASKELL__ >= 706
+  toEnum :: Int -> Default a
+  fromEnum :: Default a -> Int
+#endif
   toEnum = Default . toEnumDefault
   fromEnum (Default x) = fromEnumDefault x
 
 instance (Generic a, GEq a, Enum' (Rep a)) => GEnum (Default a) where
+#if __GLASGOW_HASKELL__ >= 706
+  genum :: [Default a]
+#endif
   genum = Default . to <$> enum'
 
 --------------------------------------------------------------------------------
@@ -77,9 +90,15 @@ instance (Generic a, GEq a, Enum' (Rep a)) => GEnum (Default a) where
 --------------------------------------------------------------------------------
 
 instance (Generic a, GShow' (Rep a)) => Show (Default a) where
+#if __GLASGOW_HASKELL__ >= 706
+  showsPrec :: Int -> Default a -> ShowS
+#endif
   showsPrec n (Default x) = gshowsPrecdefault n x
 
 instance (Generic a, GShow' (Rep a)) => GShow (Default a) where
+#if __GLASGOW_HASKELL__ >= 706
+  gshowsPrec :: Int -> Default a -> ShowS
+#endif
   gshowsPrec n (Default x) = gshowsPrecdefault n x
 
 --------------------------------------------------------------------------------
@@ -87,9 +106,15 @@ instance (Generic a, GShow' (Rep a)) => GShow (Default a) where
 --------------------------------------------------------------------------------
 
 instance (Generic a, GSemigroup' (Rep a)) => Semigroup (Default a) where
+#if __GLASGOW_HASKELL__ >= 706
+  (<>) :: Default a -> Default a -> Default a
+#endif
   Default x <> Default y = Default $ x `gsappenddefault` y
 
 instance (Generic a, GSemigroup' (Rep a)) => GSemigroup (Default a) where
+#if __GLASGOW_HASKELL__ >= 706
+  gsappend :: Default a -> Default a -> Default a
+#endif
   Default x `gsappend` Default y = Default $ x `gsappenddefault` y
 
 --------------------------------------------------------------------------------
@@ -101,10 +126,18 @@ instance (Generic a, GMonoid' (Rep a), Semigroup a, GSemigroup' (Rep a)) => Mono
 #else
 instance (Generic a, GMonoid' (Rep a)) => Monoid (Default a) where
 #endif
+#if __GLASGOW_HASKELL__ >= 706
+  mempty :: Default a
+  mappend :: Default a -> Default a -> Default a
+#endif
   mempty = Default gmemptydefault
   Default x `mappend` Default y = Default $ x `gmappenddefault` y
 
 instance (Generic a, GMonoid' (Rep a)) => GMonoid (Default a) where
+#if __GLASGOW_HASKELL__ >= 706
+  gmempty :: Default a
+  gmappend :: Default a -> Default a -> Default a
+#endif
   gmempty = Default gmemptydefault
   Default x `gmappend` Default y = Default $ x `gmappenddefault` y
 

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -89,20 +89,20 @@ import Generics.Deriving.Uniplate
 --
 -- @
 -- data MyType = …
---  deriving (Generic)
---  deriving (GEq) via (Default MyType)
+--  deriving ('Generic')
+--  deriving ('GEq') via ('Default' MyType)
 --
--- deriving via (Default MyType) instance GShow MyType
+-- deriving via ('Default' MyType) instance 'GShow' MyType
 -- @
 --
 -- Instances may be parameterized by type variables.
 --
 -- @
 -- data MyType1 a = …
---  deriving (Generic)
---  deriving (GShow) via (Default (MyType1 a))
+--  deriving ('Generic')
+--  deriving ('GShow') via ('Default' (MyType1 a))
 --
--- deriving via Default (MyType1 a) instance GEq a => GEq (MyType1 a)
+-- deriving via 'Default' (MyType1 a) instance 'GEq' a => 'GEq' (MyType1 a)
 -- @
 --
 -- These types both require instances for 'Generic'. This is because the
@@ -126,14 +126,14 @@ newtype Default a = Default { unDefault :: a }
 -- 'Data.Kind.Type'@, use 'Default1'.  An example of this class from @base@
 -- would be 'Data.Functor.Classes.Eq1', or 'Generic1'.
 --
--- Unlike for 'MyType1', there can be no implementation of these classes for @MyType :: 'Data.Kind.Type'@.
+-- Unlike for @MyType1@, there can be no implementation of these classes for @MyType :: 'Data.Kind.Type'@.
 --
 -- @
 -- data MyType1 a = …
---  deriving (Generic1)
---  deriving (GFunctor) via (Default1 MyType1)
+--  deriving ('Generic1')
+--  deriving ('GFunctor') via ('Default1' MyType1)
 --
--- deriving via (Default1 MyType1) instance GFoldable MyType1
+-- deriving via ('Default1' MyType1) instance 'GFoldable' MyType1
 -- @
 --
 -- Note that these instances require a @'Generic1' MyType1@ constraint as
@@ -160,7 +160,7 @@ instance (Generic a, GEq' (Rep a)) => GEq (Default a) where
 -- Enum
 --------------------------------------------------------------------------------
 
--- | The 'Enum' class in 'base' is slightly different; it comprises 'toEnum' and
+-- | The 'Enum' class in @base@ is slightly different; it comprises 'toEnum' and
 -- 'fromEnum'. "Generics.Deriving.Enum" provides functions 'toEnumDefault'
 -- and 'fromEnumDefault'.
 instance (Generic a, GEq a, Enum' (Rep a)) => GEnum (Default a) where
@@ -174,8 +174,8 @@ instance (Generic a, GEq a, Enum' (Rep a)) => GEnum (Default a) where
 -- | For example, with this type:
 --
 -- @
--- newtype TestShow = TestShow Bool
---   deriving (GShow) via (Default Bool)
+-- newtype TestShow = TestShow 'Bool'
+--   deriving ('GShow') via ('Default' 'Bool')
 -- @
 --
 -- 'gshow' for @TestShow@ would produce the same string as `gshow` for
@@ -196,16 +196,17 @@ instance (Generic a, GShow' (Rep a)) => GShow (Default a) where
 --------------------------------------------------------------------------------
 
 -- | Semigroups often have many sensible implementations of
--- @append/`gsappend`@, and therefore no sensible default. Indeed, there is
--- no 'GSemigroup'' instance for representations of sum types.
+-- 'Data.Semigroup.<>' / 'gsappend', and therefore no sensible default.
+-- Indeed, there is no 'GSemigroup'' instance for representations of sum
+-- types.
 --
 -- In other cases, one may wish to use the existing wrapper newtypes in
--- 'base', such as the following (using 'Data.Semigroup.First'):
+-- @base@, such as the following (using 'Data.Semigroup.First'):
 --
 -- @
--- newtype FirstSemigroup = FirstSemigroup Bool
---   deriving stock (Eq, Show)
---   deriving (GSemigroup) via (First Bool)
+-- newtype FirstSemigroup = FirstSemigroup 'Bool'
+--   deriving stock ('Eq', 'Show')
+--   deriving ('GSemigroup') via ('Data.Semigroup.First' 'Bool')
 -- @
 --
 instance (Generic a, GSemigroup' (Rep a)) => GSemigroup (Default a) where

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -41,6 +41,7 @@ module Generics.Deriving.Default
 import Generics.Deriving.Base
 import Generics.Deriving.Enum
 import Generics.Deriving.Eq
+import Generics.Deriving.Semigroup
 import Generics.Deriving.Show
 
 newtype Default a = Default a
@@ -75,4 +76,14 @@ instance (Generic a, GShow' (Rep a)) => Show (Default a) where
 
 instance (Generic a, GShow' (Rep a)) => GShow (Default a) where
   gshowsPrec n (Default x) = gshowsPrecdefault n x
+
+--------------------------------------------------------------------------------
+-- Semigroup
+--------------------------------------------------------------------------------
+
+instance (Generic a, GSemigroup' (Rep a)) => Semigroup (Default a) where
+  Default x <> Default y = Default $ x `gsappenddefault` y
+
+instance (Generic a, GSemigroup' (Rep a)) => GSemigroup (Default a) where
+  Default x `gsappend` Default y = Default $ x `gsappenddefault` y
 

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -62,6 +62,11 @@ module Generics.Deriving.Default
   , Default1(..)
   ) where
 
+#if !(MIN_VERSION_base(4,8,0))
+import Control.Applicative ((<$>))
+#endif
+import Control.Monad (liftM)
+
 import Generics.Deriving.Base
 import Generics.Deriving.Copoint
 import Generics.Deriving.Enum
@@ -189,12 +194,12 @@ instance (Generic a, Uniplate' (Rep a) a, Context' (Rep a) a) => Uniplate (Defau
   -- transform  ::            (Default a ->    Default a)  ->  Default a  ->    Default a
   -- transformM :: Monad m => (Default a -> m (Default a)) ->  Default a  -> m (Default a)
 
-  children     (Default x)    = Default <$> childrendefault    x
-  context      (Default x) ys = Default  $  contextdefault     x   (unDefault <$> ys)
-  descend    f (Default x)    = Default  $  descenddefault         (unDefault . f . Default) x
-  descendM   f (Default x)    = Default <$> descendMdefault   (fmap unDefault . f . Default) x
-  transform  f (Default x)    = Default  $  transformdefault       (unDefault . f . Default) x
-  transformM f (Default x)    = Default <$> transformMdefault (fmap unDefault . f . Default) x
+  children     (Default x)    =       Default <$> childrendefault    x
+  context      (Default x) ys =       Default  $  contextdefault     x    (unDefault <$> ys)
+  descend    f (Default x)    =       Default  $  descenddefault          (unDefault . f . Default) x
+  descendM   f (Default x)    = liftM Default  $  descendMdefault   (liftM unDefault . f . Default) x
+  transform  f (Default x)    =       Default  $  transformdefault        (unDefault . f . Default) x
+  transformM f (Default x)    = liftM Default  $  transformMdefault (liftM unDefault . f . Default) x
 
 --------------------------------------------------------------------------------
 -- Functor

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -1,11 +1,11 @@
 -- |
 -- Module      : Generics.Deriving.Default
--- Description : Default implementations of generic classes, for
--- DerivingVia
+-- Description : Default implementations of generic classes
+-- License     : BSD-3-Clause
 --
--- Maintainer  : David Baynard <haskell@baynard.me>
+-- Maintainer  : generics@haskell.org
 -- Stability   : experimental
--- Portability : portable
+-- Portability : non-portable
 --
 -- GHC 8.6 introduced the 'DerivingVia' language extension, which means
 -- an instance of a typeclass for a type can be derived from an instance

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -41,10 +41,13 @@ module Generics.Deriving.Default
   ( Default(..)
   ) where
 
+import Data.Foldable
+
 import Generics.Deriving.Base
 import Generics.Deriving.Copoint
 import Generics.Deriving.Enum
 import Generics.Deriving.Eq
+import Generics.Deriving.Foldable
 import Generics.Deriving.Functor
 import Generics.Deriving.Monoid
 import Generics.Deriving.Semigroup
@@ -190,3 +193,32 @@ instance (Generic1 f, GCopoint' (Rep1 f)) => GCopoint (Default1 f) where
 #endif
   gcopoint = gcopointdefault . unDefault1
 
+--------------------------------------------------
+-- Foldable
+--------------------------------------------------
+
+instance (Generic1 t, GFoldable' (Rep1 t)) => Foldable (Default1 t) where
+#if __GLASGOW_HASKELL__ >= 706
+  foldMap :: (Monoid m) => (a -> m) -> Default1 t a -> m
+  fold    ::  Monoid m              => Default1 t m -> m
+  foldr   :: (a -> b -> b)    -> b  -> Default1 t a -> b
+  foldr'  :: (a -> b -> b)    -> b  -> Default1 t a -> b
+  foldl   :: (a -> b -> a)    -> a  -> Default1 t b -> a
+  foldl'  :: (a -> b -> a)    -> a  -> Default1 t b -> a
+  foldr1  :: (a -> a -> a)          -> Default1 t a -> a
+  foldl1  :: (a -> a -> a)          -> Default1 t a -> a
+#endif
+  foldMap = gfoldMap
+  fold    = gfold
+  foldr   = gfoldr
+  foldr'  = gfoldr'
+  foldl   = gfoldl
+  foldl'  = gfoldl'
+  foldr1  = gfoldr1
+  foldl1  = gfoldl1
+
+instance (Generic1 t, GFoldable' (Rep1 t)) => GFoldable (Default1 t) where
+#if __GLASGOW_HASKELL__ >= 706
+  gfoldMap :: Monoid m => (a -> m) -> Default1 t a -> m
+#endif
+  gfoldMap f (Default1 tx) = gfoldMapdefault f tx

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -44,12 +44,15 @@ module Generics.Deriving.Default
 import Generics.Deriving.Base
 import Generics.Deriving.Enum
 import Generics.Deriving.Eq
+import Generics.Deriving.Functor
 import Generics.Deriving.Monoid
 import Generics.Deriving.Semigroup
 import Generics.Deriving.Show
 import Generics.Deriving.Uniplate
 
 newtype Default a = Default { unDefault :: a }
+
+newtype Default1 f a = Default1 { unDefault1 :: f a }
 
 --------------------------------------------------------------------------------
 -- Eq
@@ -162,3 +165,16 @@ instance (Generic a, Uniplate' (Rep a) a, Context' (Rep a) a) => Uniplate (Defau
   descendM   f (Default x)    = Default <$> descendMdefault   (fmap unDefault . f . Default) x
   transform  f (Default x)    = Default  $  transformdefault       (unDefault . f . Default) x
   transformM f (Default x)    = Default <$> transformMdefault (fmap unDefault . f . Default) x
+
+--------------------------------------------------------------------------------
+-- Functor
+--------------------------------------------------------------------------------
+
+instance (Generic1 f, GFunctor' (Rep1 f)) => Functor (Default1 f) where
+  fmap = gmap
+
+instance (Generic1 f, GFunctor' (Rep1 f)) => GFunctor (Default1 f) where
+#if __GLASGOW_HASKELL__ >= 706
+  gmap :: (a -> b) -> (Default1 f) a -> (Default1 f) b
+#endif
+  gmap f (Default1 fx) = Default1 $ gmapdefault f fx

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -1,0 +1,5 @@
+module Generics.Deriving.Default
+  ( Default(..)
+  ) where
+
+newtype Default a = Default a

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -1,3 +1,31 @@
+-- |
+-- Module      : Generics.Deriving.Default
+-- Description : Default implementations of generic classes, for
+-- DerivingVia
+--
+-- Maintainer  : David Baynard <haskell@baynard.me>
+-- Stability   : experimental
+-- Portability : portable
+--
+-- GHC 8.6 introduced the 'DerivingVia' language extension, which means
+-- an instance of a typeclass for a type can be derived from an instance
+-- for an isomorphic type.
+--
+-- There are a number of default instantiations for the classes to be
+-- derived via generics in this package. This module exports the 'Default'
+-- newtype, which indicates that a type should use those default instances
+-- for its typeclass instances.
+--
+-- Use as follows:
+--
+-- @
+-- data MyType = …
+--  deriving (Generic)
+--  deriving (Eq) via (Default MyType)
+--
+-- deriving via (Default MyType) instance Show MyType
+-- @
+
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE DefaultSignatures #-}

--- a/src/Generics/Deriving/Default.hs
+++ b/src/Generics/Deriving/Default.hs
@@ -39,8 +39,6 @@ module Generics.Deriving.Default
   , Default1(..)
   ) where
 
-import Data.Foldable
-
 import Generics.Deriving.Base
 import Generics.Deriving.Copoint
 import Generics.Deriving.Enum
@@ -61,10 +59,14 @@ newtype Default1 f a = Default1 { unDefault1 :: f a }
 -- Eq
 --------------------------------------------------------------------------------
 
-instance (Generic a, GEq' (Rep a)) => Eq (Default a) where
-  -- (==) :: Default a -> Default a -> Bool
-  Default x == Default y = x `geqdefault` y
-
+-- |
+--
+-- @
+-- instance (Generic a, GEq' (Rep a)) => Eq (Default a) where
+--   (==) :: Default a -> Default a -> Bool
+--   Default x == Default y = x `geqdefault` y
+-- @
+--
 instance (Generic a, GEq' (Rep a)) => GEq (Default a) where
   -- geq :: Default a -> Default a -> Bool
   Default x `geq` Default y = x `geqdefault` y
@@ -73,13 +75,17 @@ instance (Generic a, GEq' (Rep a)) => GEq (Default a) where
 -- Enum
 --------------------------------------------------------------------------------
 
-instance (Generic a, GEq a, Enum' (Rep a)) => Enum (Default a) where
-  -- toEnum :: Int -> Default a
-  toEnum = Default . toEnumDefault
-
-  -- fromEnum :: Default a -> Int
-  fromEnum (Default x) = fromEnumDefault x
-
+-- |
+--
+-- @
+-- instance (Generic a, GEq a, Enum' (Rep a)) => Enum (Default a) where
+--   toEnum :: Int -> Default a
+--   toEnum = Default . toEnumDefault
+--
+--   fromEnum :: Default a -> Int
+--   fromEnum (Default x) = fromEnumDefault x
+-- @
+--
 instance (Generic a, GEq a, Enum' (Rep a)) => GEnum (Default a) where
   -- genum :: [Default a]
   genum = Default . to <$> enum'
@@ -88,10 +94,14 @@ instance (Generic a, GEq a, Enum' (Rep a)) => GEnum (Default a) where
 -- Show
 --------------------------------------------------------------------------------
 
-instance (Generic a, GShow' (Rep a)) => Show (Default a) where
-  -- showsPrec :: Int -> Default a -> ShowS
-  showsPrec = gshowsPrec
-
+-- |
+--
+-- @
+-- instance (Generic a, GShow' (Rep a)) => Show (Default a) where
+--   showsPrec :: Int -> Default a -> ShowS
+--   showsPrec = gshowsPrec
+-- @
+--
 instance (Generic a, GShow' (Rep a)) => GShow (Default a) where
   -- gshowsPrec :: Int -> Default a -> ShowS
   gshowsPrec n (Default x) = gshowsPrecdefault n x
@@ -100,10 +110,14 @@ instance (Generic a, GShow' (Rep a)) => GShow (Default a) where
 -- Semigroup
 --------------------------------------------------------------------------------
 
-instance (Generic a, GSemigroup' (Rep a)) => Semigroup (Default a) where
-  -- (<>) :: Default a -> Default a -> Default a
-  (<>) = gsappend
-
+-- |
+--
+-- @
+-- instance (Generic a, GSemigroup' (Rep a)) => Semigroup (Default a) where
+--   (<>) :: Default a -> Default a -> Default a
+--   (<>) = gsappend
+-- @
+--
 instance (Generic a, GSemigroup' (Rep a)) => GSemigroup (Default a) where
   -- gsappend :: Default a -> Default a -> Default a
   Default x `gsappend` Default y = Default $ x `gsappenddefault` y
@@ -112,18 +126,22 @@ instance (Generic a, GSemigroup' (Rep a)) => GSemigroup (Default a) where
 -- Monoid
 --------------------------------------------------------------------------------
 
-#if (MIN_VERSION_base(4,11,0))
-instance (Generic a, GMonoid' (Rep a), Semigroup a, GSemigroup' (Rep a)) => Monoid (Default a) where
-#else
-instance (Generic a, GMonoid' (Rep a)) => Monoid (Default a) where
-#endif
-
-  -- mempty :: Default a
-  mempty = gmempty
-
-  -- mappend :: Default a -> Default a -> Default a
-  mappend = gmappend
-
+-- |
+--
+-- @
+-- #if (MIN_VERSION_base(4,11,0))
+-- instance (Generic a, GMonoid' (Rep a), Semigroup a, GSemigroup' (Rep a)) => Monoid (Default a) where
+-- #else
+-- instance (Generic a, GMonoid' (Rep a)) => Monoid (Default a) where
+-- #endif
+--
+--   mempty :: Default a
+--   mempty = gmempty
+--
+--   mappend :: Default a -> Default a -> Default a
+--   mappend = gmappend
+-- @
+--
 instance (Generic a, GMonoid' (Rep a)) => GMonoid (Default a) where
   -- gmempty :: Default a
   gmempty = Default gmemptydefault
@@ -155,9 +173,13 @@ instance (Generic a, Uniplate' (Rep a) a, Context' (Rep a) a) => Uniplate (Defau
 -- Functor
 --------------------------------------------------------------------------------
 
-instance (Generic1 f, GFunctor' (Rep1 f)) => Functor (Default1 f) where
-  fmap = gmap
-
+-- |
+--
+-- @
+-- instance (Generic1 f, GFunctor' (Rep1 f)) => Functor (Default1 f) where
+--   fmap = gmap
+-- @
+--
 instance (Generic1 f, GFunctor' (Rep1 f)) => GFunctor (Default1 f) where
   -- gmap :: (a -> b) -> (Default1 f) a -> (Default1 f) b
   gmap f (Default1 fx) = Default1 $ gmapdefault f fx
@@ -174,26 +196,30 @@ instance (Generic1 f, GCopoint' (Rep1 f)) => GCopoint (Default1 f) where
 -- Foldable
 --------------------------------------------------
 
-instance (Generic1 t, GFoldable' (Rep1 t)) => Foldable (Default1 t) where
-
-  -- foldMap :: (Monoid m) => (a -> m) -> Default1 t a -> m
-  -- fold    ::  Monoid m              => Default1 t m -> m
-  -- foldr   :: (a -> b -> b)    -> b  -> Default1 t a -> b
-  -- foldr'  :: (a -> b -> b)    -> b  -> Default1 t a -> b
-  -- foldl   :: (a -> b -> a)    -> a  -> Default1 t b -> a
-  -- foldl'  :: (a -> b -> a)    -> a  -> Default1 t b -> a
-  -- foldr1  :: (a -> a -> a)          -> Default1 t a -> a
-  -- foldl1  :: (a -> a -> a)          -> Default1 t a -> a
-
-  foldMap = gfoldMap
-  fold    = gfold
-  foldr   = gfoldr
-  foldr'  = gfoldr'
-  foldl   = gfoldl
-  foldl'  = gfoldl'
-  foldr1  = gfoldr1
-  foldl1  = gfoldl1
-
+-- |
+--
+-- @
+-- instance (Generic1 t, GFoldable' (Rep1 t)) => Foldable (Default1 t) where
+--
+--   foldMap :: (Monoid m) => (a -> m) -> Default1 t a -> m
+--   fold    ::  Monoid m              => Default1 t m -> m
+--   foldr   :: (a -> b -> b)    -> b  -> Default1 t a -> b
+--   foldr'  :: (a -> b -> b)    -> b  -> Default1 t a -> b
+--   foldl   :: (a -> b -> a)    -> a  -> Default1 t b -> a
+--   foldl'  :: (a -> b -> a)    -> a  -> Default1 t b -> a
+--   foldr1  :: (a -> a -> a)          -> Default1 t a -> a
+--   foldl1  :: (a -> a -> a)          -> Default1 t a -> a
+--
+--   foldMap = gfoldMap
+--   fold    = gfold
+--   foldr   = gfoldr
+--   foldr'  = gfoldr'
+--   foldl   = gfoldl
+--   foldl'  = gfoldl'
+--   foldr1  = gfoldr1
+--   foldl1  = gfoldl1
+-- @
+--
 instance (Generic1 t, GFoldable' (Rep1 t)) => GFoldable (Default1 t) where
   -- gfoldMap :: Monoid m => (a -> m) -> Default1 t a -> m
   gfoldMap f (Default1 tx) = gfoldMapdefault f tx
@@ -202,18 +228,22 @@ instance (Generic1 t, GFoldable' (Rep1 t)) => GFoldable (Default1 t) where
 -- Traversable
 --------------------------------------------------
 
-instance (Generic1 t, GFunctor' (Rep1 t), GFoldable' (Rep1 t), GTraversable' (Rep1 t)) => Traversable (Default1 t) where
-
-  -- traverse  :: Applicative f => (a -> f b) -> Default1 t    a  -> f (Default1 t b)
-  -- sequenceA :: Applicative f =>               Default1 t (f a) -> f (Default1 t a)
-  -- mapM      ::       Monad m => (a -> m b) -> Default1 t    a  -> m (Default1 t b)
-  -- sequence  ::       Monad m =>               Default1 t (m a) -> m (Default1 t a)
-
-  sequenceA = gsequenceA
-  mapM      = gmapM
-  sequence  = gsequence
-  traverse  = gtraverse
-
+-- |
+--
+-- @
+-- instance (Generic1 t, GFunctor' (Rep1 t), GFoldable' (Rep1 t), GTraversable' (Rep1 t)) => Traversable (Default1 t) where
+--
+--   traverse  :: Applicative f => (a -> f b) -> Default1 t    a  -> f (Default1 t b)
+--   sequenceA :: Applicative f =>               Default1 t (f a) -> f (Default1 t a)
+--   mapM      ::       Monad m => (a -> m b) -> Default1 t    a  -> m (Default1 t b)
+--   sequence  ::       Monad m =>               Default1 t (m a) -> m (Default1 t a)
+--
+--   sequenceA = gsequenceA
+--   mapM      = gmapM
+--   sequence  = gsequence
+--   traverse  = gtraverse
+-- @
+--
 instance (Generic1 t, GFunctor' (Rep1 t), GFoldable' (Rep1 t), GTraversable' (Rep1 t)) => GTraversable (Default1 t) where
   -- gtraverse :: Applicative f => (a -> f b) -> Default1 t a -> f (Default1 t b)
   gtraverse f (Default1 fx) = Default1 <$> gtraversedefault f fx

--- a/src/Generics/Deriving/Uniplate.hs
+++ b/src/Generics/Deriving/Uniplate.hs
@@ -54,6 +54,9 @@ module Generics.Deriving.Uniplate (
 
   -- * Internal Uniplate class
   , Uniplate'(..)
+
+  -- * Internal Context class
+  , Context'(..)
   ) where
 
 

--- a/tests/DefaultSpec.hs
+++ b/tests/DefaultSpec.hs
@@ -1,10 +1,11 @@
 -- |
 -- Module      : DefaultSpec
 -- Description : Ensure that deriving via Default newtype works
+-- License     : BSD-3-Clause
 --
--- Maintainer  : David Baynard <haskell@baynard.me>
+-- Maintainer  : generics@haskell.org
 -- Stability   : experimental
--- Portability : portable
+-- Portability : non-portable
 --
 -- Tests DerivingVia on GHC versions 8.6 and above.
 

--- a/tests/DefaultSpec.hs
+++ b/tests/DefaultSpec.hs
@@ -1,0 +1,22 @@
+-- |
+-- Module      : DefaultSpec
+-- Description : Ensure that deriving via Default newtype works
+--
+-- Maintainer  : David Baynard <haskell@baynard.me>
+-- Stability   : experimental
+-- Portability : portable
+--
+-- Tests DerivingVia on GHC versions 8.6 and above.
+
+module DefaultSpec (main, spec) where
+
+import Test.Hspec
+import Generics.Deriving.Default
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "DerivingVia Default" $ do
+    undefined

--- a/tests/DefaultSpec.hs
+++ b/tests/DefaultSpec.hs
@@ -16,7 +16,9 @@
 module DefaultSpec where
 
 import Test.Hspec
-import Generics.Deriving.Default
+import Generics.Deriving
+import Generics.Deriving.Default ()
+import Generics.Deriving.Foldable
 
 spec :: Spec
 spec = do
@@ -25,14 +27,14 @@ spec = do
 
 #if __GLASGOW_HASKELL__ >= 806
 newtype TestEq = TestEq Bool
-  deriving (Eq) via (Default Bool)
+  deriving (GEq) via (Default Bool)
 newtype TestEnum = TestEnum Bool
-  deriving (Enum) via (Default Bool)
+  deriving (GEnum) via (Default Bool)
 newtype TestShow = TestShow Bool
-  deriving (Show) via (Default Bool)
+  deriving (GShow) via (Default Bool)
 
 newtype TestFoldable a = TestFoldable (Maybe a)
-  deriving (Foldable) via (Default1 Maybe)
+  deriving (GFoldable) via (Default1 Maybe)
 newtype TestFunctor a = TestFunctor (Maybe a)
-  deriving (Functor) via (Default1 Maybe)
+  deriving (GFunctor) via (Default1 Maybe)
 #endif

--- a/tests/DefaultSpec.hs
+++ b/tests/DefaultSpec.hs
@@ -15,8 +15,10 @@
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 806
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 #endif
 
 module DefaultSpec where
@@ -83,13 +85,22 @@ spec = do
 
       in  functor_prop <$> universe
 
+    it "GEq is commutative for parameterized derivingVia (Default (TestFoldable Bool))" . sequenceA_ $
+      let commutative :: GEq a => a -> a -> Expectation
+          commutative x y = x `geq` y `shouldBe` y `geq` x
+
+          universe :: [TestHigherEq Bool]
+          universe = TestHigherEq <$> [Nothing, Just False, Just True]
+
+      in  commutative <$> universe <*> universe
+
 #endif
     return ()
 
 #if __GLASGOW_HASKELL__ >= 806
 
--- These types all implement instances using `DerivingVia`. Most use
--- `Default` (one uses `First` for )
+-- These types all implement instances using `DerivingVia`: most via
+-- `Default` (one uses `First`).
 
 newtype TestEq = TestEq Bool
   deriving (GEq) via (Default Bool)
@@ -105,7 +116,12 @@ newtype FirstSemigroup = FirstSemigroup Bool
 
 newtype TestFoldable a = TestFoldable (Maybe a)
   deriving (GFoldable) via (Default1 Option)
+
 newtype TestFunctor a = TestFunctor (Maybe a)
   deriving stock (Eq, Show, Functor)
   deriving (GFunctor) via (Default1 Maybe)
+
+newtype TestHigherEq a = TestHigherEq (Maybe a)
+  deriving stock (Generic)
+  deriving (GEq) via (Default (TestHigherEq a))
 #endif

--- a/tests/DefaultSpec.hs
+++ b/tests/DefaultSpec.hs
@@ -1,6 +1,6 @@
 -- |
 -- Module      : DefaultSpec
--- Description : Ensure that deriving via Default newtype works
+-- Description : Ensure that deriving via (Default  a)newtype works
 -- License     : BSD-3-Clause
 --
 -- Maintainer  : generics@haskell.org
@@ -8,11 +8,13 @@
 -- Portability : non-portable
 --
 -- Tests DerivingVia on GHC versions 8.6 and above.
+{-# LANGUAGE DerivingVia #-}
 
 module DefaultSpec (main, spec) where
 
 import Test.Hspec
 import Generics.Deriving.Default
+import Generics.Deriving
 
 main :: IO ()
 main = hspec spec
@@ -21,3 +23,15 @@ spec :: Spec
 spec = do
   describe "DerivingVia Default" $ do
     undefined
+
+newtype TestEq = TestEq Bool
+  deriving (Eq) via (Default Bool)
+newtype TestEnum = TestEnum Bool
+  deriving (Enum) via (Default Bool)
+newtype TestShow = TestShow Bool
+  deriving (Show) via (Default Bool)
+
+newtype TestFoldable a = TestFoldable (Maybe a)
+  deriving (Foldable) via (Default1 Maybe)
+newtype TestFunctor a = TestFunctor (Maybe a)
+  deriving (Functor) via (Default1 Maybe)

--- a/tests/DefaultSpec.hs
+++ b/tests/DefaultSpec.hs
@@ -1,40 +1,111 @@
 -- |
 -- Module      : DefaultSpec
--- Description : Ensure that deriving via (Default  a)newtype works
+-- Description : Ensure that deriving via (Default a) newtype works
 -- License     : BSD-3-Clause
 --
 -- Maintainer  : generics@haskell.org
 -- Stability   : experimental
 -- Portability : non-portable
 --
--- Tests DerivingVia on GHC versions 8.6 and above.
+-- Tests DerivingVia on GHC versions 8.6 and above. There are no tests on
+-- versions below.
+--
+-- The test check a miscellany of properties of the derived type classes.
+-- (Testing all the required properties is beyond the scope of this module.)
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 806
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 #endif
 
 module DefaultSpec where
 
 import Test.Hspec
-import Generics.Deriving
+
+#if __GLASGOW_HASKELL__ >= 806
+import Test.Hspec.QuickCheck
+
+import Data.Semigroup (First(..), Option(..))
+import Data.Foldable (sequenceA_)
+import Generics.Deriving hiding (universe)
 import Generics.Deriving.Default ()
-import Generics.Deriving.Foldable
+import Generics.Deriving.Foldable (GFoldable(..))
+import Generics.Deriving.Semigroup (GSemigroup(..))
+#endif
 
 spec :: Spec
 spec = do
   describe "DerivingVia Default" $ do
+
+#if __GLASGOW_HASKELL__ >= 806
+    it "GEq is commutative for derivingVia (Default Bool)" . sequenceA_ $
+      let commutative :: GEq a => a -> a -> Expectation
+          commutative x y = x `geq` y `shouldBe` y `geq` x
+
+          universe :: [TestEq]
+          universe = TestEq <$> [False, True]
+
+      in  commutative <$> universe <*> universe
+
+    it "GENum is correct for derivingVia (Default Bool)" $
+      genum `shouldBe` [TestEnum False, TestEnum True]
+
+    it "GShow for TestShow is the same as Show for Bool with derivingVia (Default Bool)" $ do
+      gshowsPrec 0 (TestShow False) "" `shouldBe` showsPrec 0 False ""
+      gshowsPrec 0 (TestShow True) "" `shouldBe` showsPrec 0 True ""
+
+    it "GSemigroup is like First when instantiated with derivingVia (First Bool)" . sequenceA_ $
+      let first' :: (Eq a, Show a, GSemigroup a) => a -> a -> Expectation
+          first' x y = x `gsappend` y `shouldBe` x
+
+          universe :: [FirstSemigroup]
+          universe = FirstSemigroup <$> [False, True]
+
+      in  first' <$> universe <*> universe
+
+    prop "GFoldable with derivingVia (Default1 Option) acts like mconcat with Maybe (First Bool)" $ \(xs :: [Maybe Bool]) ->
+      let ys :: [Maybe (First Bool)]
+          -- Note that there is no Arbitrary instance for this type
+          ys = fmap First <$> xs
+
+          unTestFoldable :: TestFoldable a -> Maybe a
+          unTestFoldable (TestFoldable x) = x
+
+      in  gfoldMap unTestFoldable (TestFoldable <$> ys) `shouldBe` mconcat ys
+
+    it "GFunctor for TestFunctor Bool is as Functor for Maybe Bool" . sequenceA_ $
+      let universe :: [Maybe Bool]
+          universe = [Nothing, Just False, Just True]
+
+          functor_prop :: Maybe Bool -> Expectation
+          functor_prop x = gmap not (TestFunctor x) `shouldBe` TestFunctor (not <$> x)
+
+      in  functor_prop <$> universe
+
+#endif
     return ()
 
 #if __GLASGOW_HASKELL__ >= 806
+
+-- These types all implement instances using `DerivingVia`. Most use
+-- `Default` (one uses `First` for )
+
 newtype TestEq = TestEq Bool
   deriving (GEq) via (Default Bool)
 newtype TestEnum = TestEnum Bool
+  deriving stock (Eq, Show)
   deriving (GEnum) via (Default Bool)
 newtype TestShow = TestShow Bool
   deriving (GShow) via (Default Bool)
 
+newtype FirstSemigroup = FirstSemigroup Bool
+  deriving stock (Eq, Show)
+  deriving (GSemigroup) via (First Bool)
+
 newtype TestFoldable a = TestFoldable (Maybe a)
-  deriving (GFoldable) via (Default1 Maybe)
+  deriving (GFoldable) via (Default1 Option)
 newtype TestFunctor a = TestFunctor (Maybe a)
+  deriving stock (Eq, Show, Functor)
   deriving (GFunctor) via (Default1 Maybe)
 #endif

--- a/tests/DefaultSpec.hs
+++ b/tests/DefaultSpec.hs
@@ -8,6 +8,8 @@
 -- Portability : non-portable
 --
 -- Tests DerivingVia on GHC versions 8.6 and above.
+{-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DerivingVia #-}
 
 module DefaultSpec (main, spec) where

--- a/tests/DefaultSpec.hs
+++ b/tests/DefaultSpec.hs
@@ -8,24 +8,22 @@
 -- Portability : non-portable
 --
 -- Tests DerivingVia on GHC versions 8.6 and above.
-{-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 806
 {-# LANGUAGE DerivingVia #-}
+#endif
 
-module DefaultSpec (main, spec) where
+module DefaultSpec where
 
 import Test.Hspec
 import Generics.Deriving.Default
-import Generics.Deriving
-
-main :: IO ()
-main = hspec spec
 
 spec :: Spec
 spec = do
   describe "DerivingVia Default" $ do
-    undefined
+    return ()
 
+#if __GLASGOW_HASKELL__ >= 806
 newtype TestEq = TestEq Bool
   deriving (Eq) via (Default Bool)
 newtype TestEnum = TestEnum Bool
@@ -37,3 +35,4 @@ newtype TestFoldable a = TestFoldable (Maybe a)
   deriving (Foldable) via (Default1 Maybe)
 newtype TestFunctor a = TestFunctor (Maybe a)
   deriving (Functor) via (Default1 Maybe)
+#endif


### PR DESCRIPTION
Fixes #58 

The module doesn't compile with the following in `DefaultSpec`:

```
newtype TestUniplate = TestUniplate Bool
  deriving (Uniplate) via (Default Bool)
```

The error is that the `m` in the `descendM` and `transformM` type signatures is inferred as nominal. I managed to get the `Uniplate` module compiling by adding the following quantified constraint to those class methods, but I haven't finished propagating that through the `Default` module.

```
type Coercible1 m = forall xx yy. Coercible xx yy => Coercible (m xx) (m yy)
```

(As an aside, I'm getting some annoying kind errors when using that as a synonym: 'Expected a type but [RHS] has kind Constraint')

Also not yet compliling is the following — though I just stubbed it out with Maybe and haven't investigated a product type.

```
newtype TestTraversable a = TestTraversable (Maybe a)
  deriving (Functor, Foldable, Traversable) via (Default1 Maybe)
```

The similar example Semigroup/Monoid compilation failures were my fault, as without noticing I'd managed to pick a sum type every time.