### PR TITLE
Support building with GHC 8.9

### DIFF
--- a/src/Generics/Deriving/Instances.hs
+++ b/src/Generics/Deriving/Instances.hs
@@ -27,7 +27,7 @@
 module Generics.Deriving.Instances (
 -- Only instances from Generics.Deriving.Base
 -- and the Generic1 instances
-#if !(MIN_VERSION_base(4,14,0))
+#if !(MIN_VERSION_base(4,14,0)) && !(MIN_VERSION_base(4,13,0))
     Rep0Kleisli
   , Rep1Kleisli
 #endif
@@ -159,15 +159,15 @@ import GHC.Exts (Down(..))
 # endif
 #endif
 
-#if !(MIN_VERSION_base(4,14,0))
+#if !(MIN_VERSION_base(4,14,0)) && !(MIN_VERSION_base(4,13,0))
 import Control.Arrow (Kleisli(..))
 #endif
 
-#if !(MIN_VERSION_base(4,14,0))
+#if !(MIN_VERSION_base(4,14,0)) && !(MIN_VERSION_base(4,13,0))
 import Generics.Deriving.Base.Internal
 #endif
 
-#if !(MIN_VERSION_base(4,14,0))
+#if !(MIN_VERSION_base(4,14,0)) && !(MIN_VERSION_base(4,13,0))
 # if MIN_VERSION_base(4,6,0)
 type Rep0Kleisli m a b = Rep  (Kleisli m a b)
 type Rep1Kleisli m a   = Rep1 (Kleisli m a)


### PR DESCRIPTION
The currently-unreleased GHC HEAD is 8.9, which comes with base-4.13.
This commit slightly specialise some CPP macros inside Instances.hs to
make sure this build not only on GHC 8.10 but also on 8.9.

@RyanGlScott Do you think this is benign enough to be merged?