### PR TITLE
Allow building with GHC 9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# next [????.??.??]
+# 1.14 [????.??.??]
+* Remove instances for `Data.Semigroup.Option`, which is deprecated as of
+  `base-4.15.0.0`.
 * Allow building with `template-haskell-2.17.0.0` (GHC 9.0).
 * Fix a bug in which `deriveAll1` would needlessly reject data types whose last
   type parameter appears as an oversaturated argument to a type family.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # next [????.??.??]
+* Allow building with `template-haskell-2.17.0.0` (GHC 9.0).
 * Fix a bug in which `deriveAll1` would needlessly reject data types whose last
   type parameter appears as an oversaturated argument to a type family.
 

--- a/generic-deriving.cabal
+++ b/generic-deriving.cabal
@@ -1,5 +1,5 @@
 name:                   generic-deriving
-version:                1.13.1
+version:                1.14
 synopsis:               Generic programming library for generalised deriving.
 description:
 

--- a/generic-deriving.cabal
+++ b/generic-deriving.cabal
@@ -105,3 +105,5 @@ test-suite spec
   hs-source-dirs:       tests
   default-language:     Haskell2010
   ghc-options:          -Wall -threaded -rtsopts
+  if impl(ghc >= 8.6)
+    ghc-options:        -Wno-star-is-type

--- a/generic-deriving.cabal
+++ b/generic-deriving.cabal
@@ -83,8 +83,8 @@ library
 
   build-depends:        containers       >= 0.1   && < 0.7
                       , ghc-prim                     < 1
-                      , template-haskell >= 2.4   && < 2.17
-                      , th-abstraction   >= 0.3   && < 0.4
+                      , template-haskell >= 2.4   && < 2.18
+                      , th-abstraction   >= 0.4   && < 0.5
 
   default-language:     Haskell2010
   ghc-options:          -Wall
@@ -100,7 +100,7 @@ test-suite spec
   build-depends:        base             >= 4.3  && < 5
                       , generic-deriving
                       , hspec            >= 2    && < 3
-                      , template-haskell >= 2.4  && < 2.17
+                      , template-haskell >= 2.4  && < 2.18
   build-tool-depends:   hspec-discover:hspec-discover
   hs-source-dirs:       tests
   default-language:     Haskell2010

--- a/src/Generics/Deriving/Enum.hs
+++ b/src/Generics/Deriving/Enum.hs
@@ -71,7 +71,7 @@ import           Numeric.Natural (Natural)
 #if MIN_VERSION_base(4,9,0)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.Semigroup as Semigroup (First, Last)
-import           Data.Semigroup (Arg, Max, Min, Option, WrappedMonoid)
+import           Data.Semigroup (Arg, Max, Min, WrappedMonoid)
 #endif
 
 -----------------------------------------------------------------------------
@@ -476,9 +476,6 @@ instance GEnum Natural where
 
 #if MIN_VERSION_base(4,9,0)
 instance GEnum a => GEnum (NonEmpty a) where
-  genum = genumDefault
-
-instance GEnum a => GEnum (Option a) where
   genum = genumDefault
 #endif
 
@@ -1016,13 +1013,6 @@ instance GIx Natural where
 
 #if MIN_VERSION_base(4,9,0)
 instance (GEq a, GEnum a, GIx a) => GIx (NonEmpty a) where
-  range   = rangeDefault
-  index   = indexDefault
-  inRange = inRangeDefault
-#endif
-
-#if MIN_VERSION_base(4,9,0)
-instance (GEq a, GEnum a, GIx a) => GIx (Option a) where
   range   = rangeDefault
   index   = indexDefault
   inRange = inRangeDefault

--- a/src/Generics/Deriving/Eq.hs
+++ b/src/Generics/Deriving/Eq.hs
@@ -72,7 +72,7 @@ import           Numeric.Natural (Natural)
 #if MIN_VERSION_base(4,9,0)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.Semigroup as Semigroup (First, Last)
-import           Data.Semigroup (Arg(..), Max, Min, Option, WrappedMonoid)
+import           Data.Semigroup (Arg(..), Max, Min, WrappedMonoid)
 #endif
 
 --------------------------------------------------------------------------------
@@ -479,9 +479,6 @@ instance GEq Natural where
 
 #if MIN_VERSION_base(4,9,0)
 instance GEq a => GEq (NonEmpty a) where
-  geq = geqdefault
-
-instance GEq a => GEq (Option a) where
   geq = geqdefault
 #endif
 

--- a/src/Generics/Deriving/Foldable.hs
+++ b/src/Generics/Deriving/Foldable.hs
@@ -81,7 +81,7 @@ import qualified Data.Functor.Product as Functor (Product)
 import qualified Data.Functor.Sum as Functor (Sum)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.Semigroup as Semigroup (First, Last)
-import           Data.Semigroup (Arg, Max, Min, Option, WrappedMonoid)
+import           Data.Semigroup (Arg, Max, Min, WrappedMonoid)
 #endif
 
 --------------------------------------------------------------------------------
@@ -241,9 +241,6 @@ instance GFoldable Min where
   gfoldMap = gfoldMapdefault
 
 instance GFoldable NonEmpty where
-  gfoldMap = gfoldMapdefault
-
-instance GFoldable Option where
   gfoldMap = gfoldMapdefault
 #endif
 

--- a/src/Generics/Deriving/Functor.hs
+++ b/src/Generics/Deriving/Functor.hs
@@ -66,7 +66,7 @@ import qualified Data.Functor.Product as Functor (Product)
 import qualified Data.Functor.Sum as Functor (Sum)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.Semigroup as Semigroup (First, Last)
-import           Data.Semigroup (Arg, Max, Min, Option, WrappedMonoid)
+import           Data.Semigroup (Arg, Max, Min, WrappedMonoid)
 #endif
 
 --------------------------------------------------------------------------------
@@ -211,9 +211,6 @@ instance GFunctor Min where
   gmap = gmapdefault
 
 instance GFunctor NonEmpty where
-  gmap = gmapdefault
-
-instance GFunctor Option where
   gmap = gmapdefault
 #endif
 

--- a/src/Generics/Deriving/Semigroup/Internal.hs
+++ b/src/Generics/Deriving/Semigroup/Internal.hs
@@ -189,9 +189,6 @@ instance Ord a => GSemigroup (Min a) where
 
 instance GSemigroup (NonEmpty a) where
   gsappend = (<>)
-
-instance GSemigroup a => GSemigroup (Option a) where
-  gsappend (Option a) (Option b) = Option (gsappend a b)
 #endif
 
 -- Tuple instances

--- a/src/Generics/Deriving/Show.hs
+++ b/src/Generics/Deriving/Show.hs
@@ -68,7 +68,7 @@ import           Numeric.Natural (Natural)
 #if MIN_VERSION_base(4,9,0)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.Semigroup as Semigroup (First, Last)
-import           Data.Semigroup (Arg, Max, Min, Option, WrappedMonoid)
+import           Data.Semigroup (Arg, Max, Min, WrappedMonoid)
 #endif
 
 --------------------------------------------------------------------------------
@@ -539,9 +539,6 @@ instance GShow Natural where
 
 #if MIN_VERSION_base(4,9,0)
 instance GShow a => GShow (NonEmpty a) where
-  gshowsPrec = gshowsPrecdefault
-
-instance GShow a => GShow (Option a) where
   gshowsPrec = gshowsPrecdefault
 #endif
 

--- a/src/Generics/Deriving/Traversable.hs
+++ b/src/Generics/Deriving/Traversable.hs
@@ -70,7 +70,7 @@ import qualified Data.Functor.Product as Functor (Product)
 import qualified Data.Functor.Sum as Functor (Sum)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.Semigroup as Semigroup (First, Last)
-import           Data.Semigroup (Arg, Max, Min, Option, WrappedMonoid)
+import           Data.Semigroup (Arg, Max, Min, WrappedMonoid)
 #endif
 
 --------------------------------------------------------------------------------
@@ -213,9 +213,6 @@ instance GTraversable Min where
   gtraverse = gtraversedefault
 
 instance GTraversable NonEmpty where
-  gtraverse = gtraversedefault
-
-instance GTraversable Option where
   gtraverse = gtraversedefault
 #endif
 

--- a/tests/DefaultSpec.hs
+++ b/tests/DefaultSpec.hs
@@ -28,7 +28,7 @@ import Test.Hspec
 #if __GLASGOW_HASKELL__ >= 806
 import Test.Hspec.QuickCheck
 
-import Data.Semigroup (First(..), Option(..))
+import Data.Semigroup (First(..))
 import Data.Foldable (sequenceA_)
 import Generics.Deriving hiding (universe)
 import Generics.Deriving.Default ()
@@ -132,7 +132,7 @@ newtype FirstSemigroup = FirstSemigroup Bool
   deriving (GSemigroup) via (First Bool)
 
 newtype TestFoldable a = TestFoldable (Maybe a)
-  deriving (GFoldable) via (Default1 Option)
+  deriving (GFoldable) via (Default1 Maybe)
 
 newtype TestFunctor a = TestFunctor (Maybe a)
   deriving stock (Eq, Show, Functor)


### PR DESCRIPTION
This PR contains a variety of commits needed to make `generic-deriving` build without warnings or errors on GHC 9.0. This involves a major version bump, as we no longer define instances for `Data.Semigroup.Option` (which is now deprecated as of `base-4.15`).