### PR TITLE
Support targets without signals (like WASI)

### DIFF
--- a/src/Generics/Deriving/Enum.hs
+++ b/src/Generics/Deriving/Enum.hs
@@ -335,7 +335,11 @@ instance GEnum CShort where
   genum = coerce (genum :: [HTYPE_SHORT])
 
 instance GEnum CSigAtomic where
+#if defined(HTYPE_SIG_ATOMIC_T)
   genum = coerce (genum :: [HTYPE_SIG_ATOMIC_T])
+#else
+  genum = coerce (genum :: [Int32])
+#endif
 
 instance GEnum CSize where
   genum = coerce (genum :: [HTYPE_SIZE_T])


### PR DESCRIPTION
The new WASM backend in GHC 9.6 doesn't have support for posix-style asynchronous signals, cf.

 - [`CSigAtomic` definition](https://gitlab.haskell.org/ghc/ghc/-/blob/bc038c3bd45ee99db9fba23a823a906735740200/libraries/base/Foreign/C/Types.hs#L185-L193)
 - [Relevant GHC note](https://gitlab.haskell.org/ghc/ghc/-/blob/bc038c3bd45ee99db9fba23a823a906735740200/rts/include/rts/Config.h#L47-L68)
