### PR TITLE
Support building with `template-haskell-2.21.*`, `th-abstraction-0.6.*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # next [????.??.??]
+* Support building with `template-haskell-2.21.*` (GHC 9.8).
 * The Template Haskell machinery now uses `TemplateHaskellQuotes` when
   building with GHC 8.0+ instead of manually constructing each Template Haskell
   `Name`. A consequence of this is that `generic-deriving` will now build with

--- a/generic-deriving.cabal
+++ b/generic-deriving.cabal
@@ -131,8 +131,11 @@ library
 
   build-depends:        containers       >= 0.1   && < 0.7
                       , ghc-prim                     < 1
-                      , template-haskell >= 2.4   && < 2.21
-                      , th-abstraction   >= 0.4   && < 0.6
+                      , template-haskell >= 2.4   && < 2.22
+                        -- TODO: Eventually, we should bump the lower version
+                        -- bounds to >=0.6 so that we can remove some CPP in
+                        -- Generics.Deriving.TH.Internal.
+                      , th-abstraction   >= 0.4   && < 0.7
 
   default-language:     Haskell2010
   ghc-options:          -Wall
@@ -150,7 +153,7 @@ test-suite spec
   build-depends:        base             >= 4.3  && < 5
                       , generic-deriving
                       , hspec            >= 2    && < 3
-                      , template-haskell >= 2.4  && < 2.21
+                      , template-haskell >= 2.4  && < 2.22
   build-tool-depends:   hspec-discover:hspec-discover
   hs-source-dirs:       tests
   default-language:     Haskell2010

--- a/src/Generics/Deriving/Enum.hs
+++ b/src/Generics/Deriving/Enum.hs
@@ -38,6 +38,7 @@ module Generics.Deriving.Enum (
 import           Control.Applicative (Const, ZipList)
 
 import           Data.Int
+import           Data.Maybe (listToMaybe)
 import           Data.Monoid (All, Any, Dual, Product, Sum)
 import qualified Data.Monoid as Monoid (First, Last)
 import Data.Word
@@ -106,9 +107,7 @@ combine f (x:xs) (y:ys) = f x y : combine f xs ys
 
 findIndex :: (a -> Bool) -> [a] -> Maybe Int
 findIndex p xs = let l = [ i | (y,i) <- zip xs [(0::Int)..], p y]
-                 in if (null l)
-                    then Nothing
-                    else Just (head l)
+                 in listToMaybe l
 
 --------------------------------------------------------------------------------
 -- Generic enum

--- a/src/Generics/Deriving/TH.hs
+++ b/src/Generics/Deriving/TH.hs
@@ -113,6 +113,7 @@ import           Generics.Deriving.TH.Pre4_9
 #endif
 
 import           Language.Haskell.TH.Datatype
+import           Language.Haskell.TH.Datatype.TyVarBndr
 import           Language.Haskell.TH.Lib
 import           Language.Haskell.TH
 
@@ -314,7 +315,7 @@ deriveRepCommon gClass useKindSigs n = do
                       then tySynVars
                       else map unKindedTV tySynVars
   fmap (:[]) $ tySynD (genRepName gClass dv name)
-                      tySynVars'
+                      (changeTVFlags bndrReq tySynVars')
                       (repType gt dv name Map.empty cons)
 
 deriveInst :: GenericClass -> Options -> Name -> Q [Dec]

--- a/src/Generics/Deriving/TH/Internal.hs
+++ b/src/Generics/Deriving/TH/Internal.hs
@@ -196,7 +196,7 @@ isUnsaturatedType = go 0 . dustOff
 
 -- | Given a name, check if that name is a type family. If
 -- so, return a list of its binders.
-getTypeFamilyBinders :: Name -> Q (Maybe [TyVarBndr_ ()])
+getTypeFamilyBinders :: Name -> Q (Maybe [TyVarBndrVis])
 getTypeFamilyBinders tcName = do
       info <- reify tcName
       return $ case info of
@@ -586,6 +586,13 @@ checkExistentialContext :: Name -> [TyVarBndrUnit] -> Cxt -> Q ()
 checkExistentialContext constrName vars ctxt =
   unless (null vars && null ctxt) $ fail $
     nameBase constrName ++ " must be a vanilla data constructor"
+
+#if !(MIN_VERSION_template_haskell(2,21,0)) && !(MIN_VERSION_th_abstraction(0,6,0))
+type TyVarBndrVis = TyVarBndrUnit
+
+bndrReq :: ()
+bndrReq = ()
+#endif
 
 -------------------------------------------------------------------------------
 -- Quoted names


### PR DESCRIPTION
Fixes https://github.com/dreixel/generic-deriving/issues/93.